### PR TITLE
add README and LICENSE to MANIFEST.in so pypi install works

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LICENSE


### PR DESCRIPTION
the install from pypi fails and README.md is not included in the package. This addresses that.
