### PR TITLE
Don't require users to download latest Ensembl every time we bump the MAX_ENSEMBL_RELEASE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ install:
   - pip install --upgrade -r $PWD/vaxrank/requirements.txt
 script:
   - ./lint.sh
+  - echo "Testing network connectivity" && ping ftp.ensembl.org
   - echo "Before installing Ensembl releases" && df -h
   # Ensembl 75
   - pyensembl install --release 75 --species human

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,9 @@ install:
       conda create -q -n $CONDA_ENV python=$TRAVIS_PYTHON_VERSION
       numpy nose pandas pandoc
   - source activate $CONDA_ENV
+  # install pysam from conda because I'm having trouble installing Cython
+  # for Python 3 on Travis
+  - conda install -c bioconda pysam=0.9.0
   - python --version #  make sure we're running the Python version we expect
   - pip install pypandoc
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-dist: precise
-sudo: true  # Use container-based infrastructure
-language: python
+dist: trusty
+sudo: false  # false = use container-based infrastructure
+language: minimal
 python:
   - "2.7"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
   - pip install --upgrade -r $PWD/vaxrank/requirements.txt
 script:
   - ./lint.sh
-  - echo "Testing network connectivity" && ping ftp.ensembl.org
+  - echo "Testing network connectivity" && ping -c 5 -q ftp.ensembl.org
   - echo "Before installing Ensembl releases" && df -h
   # Ensembl 75
   - pyensembl install --release 75 --species human

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: precise
-sudo: false  # Use container-based infrastructure
+sudo: true  # Use container-based infrastructure
 language: python
 python:
   - "2.7"

--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -17,7 +17,7 @@ from __future__ import print_function, division, absolute_import
 from .memory_cache import MemoryCache
 from .database import Database
 from .download_cache import DownloadCache
-from .ensembl_release import EnsemblRelease
+from .ensembl_release import EnsemblRelease, cached_release
 from .ensembl_release_versions import MAX_ENSEMBL_RELEASE
 from .exon import Exon
 from .genome import Genome
@@ -58,6 +58,7 @@ __all__ = [
     "DownloadCache",
     "Database",
     "EnsemblRelease",
+    "cached_release",
     "MAX_ENSEMBL_RELEASE",
     "Gene",
     "Transcript",

--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -41,7 +41,7 @@ from .species import (
 )
 from .transcript import Transcript
 
-__version__ = '1.3.1'
+__version__ = '1.3.0'
 
 __all__ = [
     "MemoryCache",

--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -41,7 +41,7 @@ from .species import (
 )
 from .transcript import Transcript
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 __all__ = [
     "MemoryCache",

--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015. Mount Sinai School of Medicine
+# Copyright (c) 2015-2018. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,21 +37,11 @@ from .sequence_data import SequenceData
 from .species import (
     find_species_by_name,
     check_species_object,
-    normalize_species_name,
+    normalize_species_name
 )
 from .transcript import Transcript
 
 __version__ = '1.3.0'
-
-def cached_release(release, species="human"):
-    """
-    Create an EnsemblRelease instance only if it's hasn't already been made,
-    otherwise returns the old instance.
-
-    Keeping this function for backwards compatibility but this functionality
-    has been moving into the cached method of EnsemblRelease.
-    """
-    return EnsemblRelease.cached(release=release, species=species)
 
 __all__ = [
     "MemoryCache",

--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -23,19 +23,25 @@ from .exon import Exon
 from .genome import Genome
 from .gene import Gene
 from .locus import Locus
+from .reference_name import (
+    ensembl_grch36,
+    ensembl_grch37,
+    ensembl_grch38,
+    normalize_reference_name,
+    find_species_by_reference,
+    which_reference,
+    genome_for_reference_name,
+)
 from .search import find_nearest_locus
 from .sequence_data import SequenceData
 from .species import (
     find_species_by_name,
-    find_species_by_reference,
-    which_reference,
     check_species_object,
-    normalize_reference_name,
     normalize_species_name,
 )
 from .transcript import Transcript
 
-__version__ = '1.2.6'
+__version__ = '1.3.0'
 
 def cached_release(release, species="human"):
     """
@@ -47,24 +53,12 @@ def cached_release(release, species="human"):
     """
     return EnsemblRelease.cached(release=release, species=species)
 
-def genome_for_reference_name(reference_name):
-    reference_name = normalize_reference_name(reference_name)
-    species = find_species_by_reference(reference_name)
-    (_, max_ensembl_release) = species.reference_assemblies[reference_name]
-    return cached_release(release=max_ensembl_release, species=species)
-
-ensembl_grch36 = ensembl54 = cached_release(54)  # last release for GRCh36/hg18
-ensembl_grch37 = ensembl75 = cached_release(75)  # last release for GRCh37/hg19
-ensembl_grch38 = cached_release(MAX_ENSEMBL_RELEASE)  # most recent for GRCh38
-
-
 __all__ = [
     "MemoryCache",
     "DownloadCache",
     "Database",
     "EnsemblRelease",
     "MAX_ENSEMBL_RELEASE",
-    "cached_release",
     "Gene",
     "Transcript",
     "Exon",
@@ -72,6 +66,7 @@ __all__ = [
     "find_nearest_locus",
     "find_species_by_name",
     "find_species_by_reference",
+    "genome_for_reference_name",
     "which_reference",
     "check_species_object",
     "normalize_reference_name",

--- a/pyensembl/common.py
+++ b/pyensembl/common.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import print_function, absolute_import
+
 from functools import wraps
 
 from six.moves import cPickle as pickle

--- a/pyensembl/download_cache.py
+++ b/pyensembl/download_cache.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2015-2018. Mount Sinai School of Medicine
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -9,6 +10,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import print_function, division, absolute_import
 
 from os import listdir, remove
 from os.path import join, exists, split, abspath

--- a/pyensembl/download_cache.py
+++ b/pyensembl/download_cache.py
@@ -1,5 +1,3 @@
-# Copyright (c) 2015. Mount Sinai School of Medicine
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -302,8 +300,8 @@ class DownloadCache(object):
         """
         for filename in listdir(self.cache_directory_path):
             delete = (
-                any(filename.endswith(ext) for ext in suffixes) or
-                any(filename.startswith(pre) for pre in prefixes))
+                any([filename.endswith(ext) for ext in suffixes]) or
+                any([filename.startswith(pre) for pre in prefixes]))
             if delete:
                 path = join(self.cache_directory_path, filename)
                 logger.info("Deleting %s", path)

--- a/pyensembl/download_cache.py
+++ b/pyensembl/download_cache.py
@@ -212,11 +212,10 @@ class DownloadCache(object):
         missing = not exists(cached_path)
         if (missing or overwrite) and download_if_missing:
             logger.info("Fetching %s from URL %s", cached_path, url)
-            local_filename = split(cached_path)[1]
-            datacache.download._download(
-                filename=local_filename,
+            datacache.download._download_and_decompress_if_necessary(
                 full_path=cached_path,
-                download_url=url)
+                download_url=url,
+                timeout=3600)
         elif missing:
             raise MissingRemoteFile(url)
         return cached_path

--- a/pyensembl/ensembl_release.py
+++ b/pyensembl/ensembl_release.py
@@ -33,7 +33,6 @@ class EnsemblRelease(Genome):
     Bundles together the genomic annotation and sequence data associated with
     a particular release of the Ensembl database.
     """
-
     @classmethod
     def normalize_init_values(cls, release, species, server):
         """
@@ -144,3 +143,12 @@ class EnsemblRelease(Genome):
         Deserialize EnsemblRelease without creating duplicate instances.
         """
         return cls.cached(**state_dict)
+
+def cached_release(release, species="human"):
+    """
+    Create an EnsemblRelease instance only if it's hasn't already been made,
+    otherwise returns the old instance.
+    Keeping this function for backwards compatibility but this functionality
+    has been moving into the cached method of EnsemblRelease.
+    """
+    return EnsemblRelease.cached(release=release, species=species)

--- a/pyensembl/ensembl_release_versions.py
+++ b/pyensembl/ensembl_release_versions.py
@@ -15,7 +15,7 @@
 from __future__ import print_function, division, absolute_import
 
 MIN_ENSEMBL_RELEASE = 54
-MAX_ENSEMBL_RELEASE = 87
+MAX_ENSEMBL_RELEASE = 90
 
 def check_release_number(release):
     """

--- a/pyensembl/ensembl_release_versions.py
+++ b/pyensembl/ensembl_release_versions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015. Mount Sinai School of Medicine
+# Copyright (c) 2015-2018. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 from __future__ import print_function, division, absolute_import
 
 MIN_ENSEMBL_RELEASE = 54
-MAX_ENSEMBL_RELEASE = 90
+MAX_ENSEMBL_RELEASE = 87
 
 def check_release_number(release):
     """

--- a/pyensembl/ensembl_release_versions.py
+++ b/pyensembl/ensembl_release_versions.py
@@ -15,7 +15,7 @@
 from __future__ import print_function, division, absolute_import
 
 MIN_ENSEMBL_RELEASE = 54
-MAX_ENSEMBL_RELEASE = 87
+MAX_ENSEMBL_RELEASE = 92
 
 def check_release_number(release):
     """

--- a/pyensembl/ensembl_url_templates.py
+++ b/pyensembl/ensembl_url_templates.py
@@ -22,6 +22,7 @@ For example, the human chromosomal DNA sequences for release 78 are in:
 
 """
 from __future__ import print_function, division, absolute_import
+
 from os.path import join
 
 from six.moves import urllib_parse

--- a/pyensembl/fasta.py
+++ b/pyensembl/fasta.py
@@ -19,6 +19,7 @@ Ensembl FTP server that no proper FASTA parser lets you skip over.
 """
 
 from __future__ import print_function, division, absolute_import
+
 from gzip import GzipFile
 import logging
 

--- a/pyensembl/locus_with_genome.py
+++ b/pyensembl/locus_with_genome.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2016. Mount Sinai School of Medicine
+# Copyright (c) 2015-2018. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import print_function, division, absolute_import
 
 from .locus import Locus
 

--- a/pyensembl/normalization.py
+++ b/pyensembl/normalization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2016-2018. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import print_function, division, absolute_import
 
 from six.moves import intern
 from typechecks import is_string, is_integer

--- a/pyensembl/reference_name.py
+++ b/pyensembl/reference_name.py
@@ -52,7 +52,6 @@ def genome_for_reference_name(
         # available
     return EnsemblRelease.cached(release=max_ensembl_release, species=species)
 
-
 ensembl_grch36 = genome_for_reference_name("ncbi36")
 ensembl_grch37 = genome_for_reference_name("grch37")
 ensembl_grch38 = genome_for_reference_name("grch38")

--- a/pyensembl/reference_name.py
+++ b/pyensembl/reference_name.py
@@ -1,3 +1,19 @@
+# Copyright (c) 2018. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division, absolute_import
+
 from .ensembl_release import EnsemblRelease
 from .species import Species, find_species_by_name
 
@@ -47,7 +63,9 @@ def genome_for_reference_name(
         # go through candidate releases in descending order
         for release in reversed(range(min_ensembl_release, max_ensembl_release + 1)):
             # check if release has been locally downloaded
-            pass
+            candidate = EnsemblRelease.cached(release=release, species=species)
+            if candidate.required_local_files_exist():
+                return candidate
         # see if any of the releases between [max, min] are already locally
         # available
     return EnsemblRelease.cached(release=max_ensembl_release, species=species)

--- a/pyensembl/reference_name.py
+++ b/pyensembl/reference_name.py
@@ -1,0 +1,58 @@
+from .ensembl_release import EnsemblRelease
+from .species import Species, find_species_by_name
+
+def normalize_reference_name(name):
+    """
+    Search the dictionary of species-specific references to find a reference
+    name that matches aside from capitalization.
+
+    If no matching reference is found, raise an exception.
+    """
+    lower_name = name.strip().lower()
+    for reference in Species._reference_names_to_species.keys():
+        if reference.lower() == lower_name:
+            return reference
+    raise ValueError("Reference genome '%s' not found" % name)
+
+def find_species_by_reference(reference_name):
+    return Species._reference_names_to_species[normalize_reference_name(reference_name)]
+
+def which_reference(species_name, ensembl_release):
+    return find_species_by_name(species_name).which_reference(ensembl_release)
+
+def max_ensembl_release(reference_name):
+    species = find_species_by_reference(reference_name)
+    (_, max_release) = species.reference_assemblies[reference_name]
+    return max_release
+
+def genome_for_reference_name(
+        reference_name,
+        allow_older_downloaded_release=True):
+    """
+    Given a genome reference name, such as "GRCh38", returns the
+    corresponding Ensembl Release object.
+
+    If `allow_older_downloaded_release` is True, and some older releases have
+    been downloaded, then return the most recent locally available release.
+
+
+    Otherwise, return the newest release of Ensembl (even if its data hasn't
+    already been downloaded).
+    """
+    reference_name = normalize_reference_name(reference_name)
+    species = find_species_by_reference(reference_name)
+    (min_ensembl_release, max_ensembl_release) = \
+        species.reference_assemblies[reference_name]
+    if allow_older_downloaded_release:
+        # go through candidate releases in descending order
+        for release in reversed(range(min_ensembl_release, max_ensembl_release + 1)):
+            # check if release has been locally downloaded
+            pass
+        # see if any of the releases between [max, min] are already locally
+        # available
+    return EnsemblRelease.cached(release=max_ensembl_release, species=species)
+
+
+ensembl_grch36 = genome_for_reference_name("ncbi36")
+ensembl_grch37 = genome_for_reference_name("grch37")
+ensembl_grch38 = genome_for_reference_name("grch38")

--- a/pyensembl/search.py
+++ b/pyensembl/search.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function, division, absolute_import
+
 """
 Helper functions for searching over collections of PyEnsembl objects
 """

--- a/pyensembl/sequence_data.py
+++ b/pyensembl/sequence_data.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
+
 from os import remove
 from os.path import exists, abspath, split, join
 import logging

--- a/pyensembl/shell.py
+++ b/pyensembl/shell.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-# Copyright (c) 2015. Mount Sinai School of Medicine
+# Copyright (c) 2015-2018. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +39,8 @@ To install any genome:
 
 """
 
-from __future__ import absolute_import
+from __future__ import print_function, division, absolute_import
+
 import argparse
 import logging
 import logging.config
@@ -79,11 +78,13 @@ release_group.add_argument(
     help="Which species to download Ensembl data for (default=%(default)s.")
 
 path_group = root_group.add_argument_group()
+
 path_group.add_argument(
     "--reference-name",
     type=str,
     default=None,
     help="Name of the reference, e.g. GRCh38")
+
 path_group.add_argument(
     "--annotation-name",
     default=None,
@@ -170,6 +171,3 @@ def run():
             genome.index(overwrite=args.overwrite)
         else:
             raise ValueError("Invalid action: %s" % args.action)
-
-if __name__ == "__main__":
-    run()

--- a/pyensembl/species.py
+++ b/pyensembl/species.py
@@ -124,35 +124,11 @@ def normalize_species_name(name):
 
     return lower_name.replace(" ", "_")
 
-def normalize_reference_name(name):
-    """
-    Search the dictionary of species-specific references to find a reference
-    name that matches aside from capitalization.
-
-    If no matching reference is found, raise an exception.
-    """
-    lower_name = name.strip().lower()
-    for reference in Species._reference_names_to_species.keys():
-        if reference.lower() == lower_name:
-            return reference
-    raise ValueError("Reference genome '%s' not found" % name)
-
 def find_species_by_name(species_name):
     latin_name = normalize_species_name(species_name)
     if latin_name not in Species._latin_names_to_species:
         raise ValueError("Species not found: %s" % species_name)
     return Species._latin_names_to_species[latin_name]
-
-def find_species_by_reference(reference_name):
-    return Species._reference_names_to_species[normalize_reference_name(reference_name)]
-
-def which_reference(species_name, ensembl_release):
-    return find_species_by_name(species_name).which_reference(ensembl_release)
-
-def max_ensembl_release(reference_name):
-    species = find_species_by_reference(reference_name)
-    (_, max_release) = species.reference_assemblies[reference_name]
-    return max_release
 
 def check_species_object(species_name_or_object):
     """

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -19,7 +19,6 @@ from memoized_property import memoized_property
 from .common import memoize
 from .locus_with_genome import LocusWithGenome
 
-
 class Transcript(LocusWithGenome):
     """
     Transcript encompasses the locus, exons, and sequence of a transcript.

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -399,10 +399,7 @@ class Transcript(LocusWithGenome):
         Spliced cDNA sequence of transcript
         (includes 5" UTR, coding sequence, and 3" UTR)
         """
-
-        if self.id in self.genome.transcript_sequences:
-            return self.genome.transcript_sequences.get(self.id)
-        return None
+        return self.genome.transcript_sequences.get(self.id)
 
     @memoized_property
     def first_start_codon_spliced_offset(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
+typechecks>=0.0.2
 numpy>=1.7
-pandas>=0.13.1
+pandas>=0.15
 datacache>=0.4.19
 memoized-property>=1.0.2
 nose>=1.3.3
-tinytimer>=0.0.0
+tinytimer
 six>=1.9.0
 pylint>=1.4.4
 gtfparse>=0.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 typechecks>=0.0.2
 numpy>=1.7
 pandas>=0.15
-datacache>=0.4.19
+datacache>=1.0.0
 memoized-property>=1.0.2
 nose>=1.3.3
 tinytimer

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
             "typechecks>=0.0.2",
             "numpy>=1.7",
             "pandas>=0.15",
-            "datacache>=0.4.19",
+            "datacache>=1.0.0",
             "memoized-property>=1.0.2",
             "six>=1.9.0",
             "gtfparse>=0.0.3",

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,11 @@ import re
 
 from setuptools import setup
 
+package_name = "pyensembl"
 current_directory = os.path.dirname(__file__)
 readme_filename = 'README.md'
 readme_path = os.path.join(current_directory, readme_filename)
+github_url = "https://github.com/openvax/%s" % package_name
 
 try:
     with open(readme_path, 'r') as f:
@@ -39,7 +41,7 @@ except ImportError as e:
     print("Failed to convert %s to reStructuredText" % readme_filename)
     pass
 
-with open('pyensembl/__init__.py', 'r') as f:
+with open('%s/__init__.py' % package_name, 'r') as f:
     version = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
         f.read(),
@@ -50,16 +52,16 @@ if not version:
 
 if __name__ == '__main__':
     setup(
-        name='pyensembl',
+        name=package_name,
         version=version,
         description="Python interface to ensembl reference genome metadata",
         author="Alex Rubinsteyn",
         author_email="alex.rubinsteyn@mssm.edu",
-        url="https://github.com/openvax/pyensembl",
+        url=github_url,
         license="http://www.apache.org/licenses/LICENSE-2.0.html",
         entry_points={
             'console_scripts': [
-                'pyensembl = pyensembl.shell:run'
+                'pyensembl = %s.shell:run' % package_name
             ],
         },
         classifiers=[
@@ -83,6 +85,6 @@ if __name__ == '__main__':
             "tinytimer",
         ],
         long_description=readme_restructured,
-        packages=['pyensembl'],
-        package_data={'pyensembl': ['logging.conf']},
+        packages=[package_name],
+        package_data={package_name: ['logging.conf']},
     )

--- a/test/test_missing_genome_sources.py
+++ b/test/test_missing_genome_sources.py
@@ -9,18 +9,27 @@ MOUSE_ENSMUSG00000017167_PATH = data_path(
     "mouse.ensembl.81.partial.ENSMUSG00000017167.gtf")
 MOUSE_ENSMUSG00000017167_TRANSCRIPT_FASTA_PATH = data_path(
     "mouse.ensembl.81.partial.ENSMUSG00000017167.fa")
-#MOUSE_ENSMUSG00000088969_NCRNA_FASTA_PATH = data_path(
+# MOUSE_ENSMUSG00000088969_NCRNA_FASTA_PATH = data_path(
 #    "mouse.ensembl.81.partial.ncrna.ENSMUSG00000017167.fa")
 MOUSE_ENSMUSG00000017167_PROTEIN_FASTA_PATH = data_path(
     "mouse.ensembl.81.partial.ENSMUSG00000017167.pep")
 
 def no_gtf_(cm):
+    print("Testing for 'GTF' in %s : %s" % (
+        type(cm.exception),
+        cm.exception))
     ok_("GTF" in str(cm.exception))
 
 def no_transcript_(cm):
+    print("Testing for 'transcript' in %s : %s" % (
+        type(cm.exception),
+        cm.exception))
     ok_("transcript" in str(cm.exception))
 
 def no_protein_(cm):
+    print("Testing for 'protein' in %s : %s" % (
+        type(cm.exception),
+        cm.exception))
     ok_("protein" in str(cm.exception))
 
 def test_transcript_fasta_only():
@@ -53,48 +62,52 @@ def test_transcript_fasta_only():
     no_protein_(cm)
 
 def test_protein_fasta_only():
-    genome = Genome(
+    genome_only_proteins = Genome(
         reference_name="GRCm38",
         annotation_name="_test_mouse_ensembl81_subset",
         protein_fasta_paths_or_urls=[MOUSE_ENSMUSG00000017167_PROTEIN_FASTA_PATH])
-    genome.index()
+    genome_only_proteins.index()
 
-    eq_(4, len(genome.protein_sequences.fasta_dictionary))
+    eq_(4, len(genome_only_proteins.protein_sequences.fasta_dictionary))
 
     with assert_raises(ValueError) as cm:
-        genome.genes()
+        genome_only_proteins.genes()
     no_gtf_(cm)
+
     with assert_raises(ValueError) as cm:
-        genome.transcript_sequence("test")
+        genome_only_proteins.transcript_sequence("DOES_NOT_EXIST")
     no_transcript_(cm)
 
 def test_gtf_only():
-    genome = Genome(
+    genome_only_gtf = Genome(
         reference_name="GRCm38",
         annotation_name="_test_mouse_ensembl81_subset",
         gtf_path_or_url=MOUSE_ENSMUSG00000017167_PATH)
-    genome.index()
+    genome_only_gtf.index()
 
-    eq_(1, len(genome.genes()))
+    eq_(1, len(genome_only_gtf.genes()))
 
     with assert_raises(ValueError) as cm:
-        genome.transcript_sequence("test")
+        genome_only_gtf.transcript_sequence("DOES_NOT_EXIST")
+
     no_transcript_(cm)
+
     with assert_raises(ValueError) as cm:
-        genome.protein_sequence("test")
+        genome_only_gtf.protein_sequence("genome_only_gtf")
+
     no_protein_(cm)
 
 def test_gtf_transcript_only():
-    genome = Genome(
+    genome_gtf_with_cdna = Genome(
         reference_name="GRCm38",
         annotation_name="_test_mouse_ensembl81_subset",
         gtf_path_or_url=MOUSE_ENSMUSG00000017167_PATH,
         transcript_fasta_paths_or_urls=[MOUSE_ENSMUSG00000017167_TRANSCRIPT_FASTA_PATH])
-    genome.index()
+    genome_gtf_with_cdna.index()
 
-    eq_(1, len(genome.genes()))
+    eq_(1, len(genome_gtf_with_cdna.genes()))
 
-    transcript = genome.transcripts()[0]
+    transcript = genome_gtf_with_cdna.transcripts()[0]
     ok_(transcript.sequence)
 
     with assert_raises(ValueError) as cm:
@@ -102,16 +115,16 @@ def test_gtf_transcript_only():
     no_protein_(cm)
 
 def test_gtf_protein_only():
-    genome = Genome(
+    genome_gtf_with_proteins = Genome(
         reference_name="GRCm38",
         annotation_name="_test_mouse_ensembl81_subset",
         gtf_path_or_url=MOUSE_ENSMUSG00000017167_PATH,
         protein_fasta_paths_or_urls=[MOUSE_ENSMUSG00000017167_PROTEIN_FASTA_PATH])
-    genome.index()
+    genome_gtf_with_proteins.index()
 
-    eq_(1, len(genome.genes()))
+    eq_(1, len(genome_gtf_with_proteins.genes()))
 
-    transcript = genome.transcripts()[0]
+    transcript = genome_gtf_with_proteins.transcripts()[0]
     ok_(transcript.protein_sequence)
 
     with assert_raises(ValueError) as cm:


### PR DESCRIPTION
The main change here is that it's now possible to check whether a `Genome` has all of its required resources locally installed and this feature is used to iterate through every possible Ensembl release associated with a reference genome and use the most recent locally installed. This fixes the annoying scenario where we update the MAX_ENSEMBL_RELEASE and then break every downstream package which installs the wrong Ensembl release for its tests.  

Also fixes: https://github.com/openvax/pyensembl/issues/188