### PR TITLE
added exception is_valid_id for yeast

### DIFF
--- a/pyensembl/common.py
+++ b/pyensembl/common.py
@@ -84,7 +84,7 @@ def memoize(fn):
 
 def is_valid_ensembl_id(ensembl_id):
     """Is the argument a valid ID for any Ensembl feature?"""
-    return is_string(ensembl_id) and ensembl_id.startswith("ENS")
+    return is_string(ensembl_id) and (ensembl_id.startswith("ENS") or ensembl_id.startswith("Y"))
 
 def require_ensembl_id(ensembl_id):
     if not is_valid_ensembl_id(ensembl_id):
@@ -92,7 +92,7 @@ def require_ensembl_id(ensembl_id):
 
 def is_valid_human_transcript_id(transcript_id):
     """Is the argument a valid identifier for human Ensembl transcripts?"""
-    return is_string(transcript_id) and transcript_id.startswith("ENST")
+    return is_string(transcript_id) and (transcript_id.startswith("ENST") or ensembl_id.startswith("Y"))
 
 def require_human_transcript_id(transcript_id):
     if not is_valid_human_transcript_id(transcript_id):
@@ -100,7 +100,7 @@ def require_human_transcript_id(transcript_id):
 
 def is_valid_human_protein_id(protein_id):
     """Is the argument a valid identifier for human Ensembl proteins?"""
-    return is_string(protein_id) and protein_id.startswith("ENSP")
+    return is_string(protein_id) and (protein_id.startswith("ENSP") or ensembl_id.startswith("Y"))
 
 def require_human_protein_id(protein_id):
     if not is_valid_human_protein_id(protein_id):


### PR DESCRIPTION
Related to issue [#209](https://github.com/openvax/pyensembl/issues/209): Add an exception for Saccharomyces cerevisiae in `is_valid_ensembl_id(ensembl_id)` function

As you would be able to notice, I have added an `or` argument to allow an exception to yeast ids (`or ensembl_id.startswith("Y")`)
I would like to acknowledge that this quick fix may cause problems if users provide gene names starting with Y (they would not get an error).

Ideally, the species name (taxonomic one) should be provided to the function. Here, I went for a quick fix because otherwise I would have to crawl back to all the places where  `is_valid_{}_id` function is used and fix them systematically.

I hope if the quick fix is ok.   
If not let me know if I should make an effort to fix this issue systematically. 