### PR TITLE
Add transcript_support_level (TSL) field

### DIFF
--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -41,7 +41,7 @@ from .species import (
 )
 from .transcript import Transcript
 
-__version__ = '1.7.1'
+__version__ = '1.7.2'
 
 __all__ = [
     "MemoryCache",

--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -890,9 +890,9 @@ class Genome(Serializable):
                 end=end,
                 strand=strand,
                 biotype=transcript_biotype,
-                support_level=tsl,
                 gene_id=gene_id,
-                genome=self)
+                genome=self,
+                support_level=tsl)
 
         return self._transcripts[transcript_id]
 

--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -844,6 +844,7 @@ class Genome(Serializable):
             optional_field_names = [
                 "transcript_name",
                 "transcript_biotype",
+                "transcript_support_level",
             ]
             field_names = [
                 "seqname",
@@ -867,17 +868,16 @@ class Genome(Serializable):
             if not result:
                 raise ValueError("Transcript not found: %s" % (transcript_id,))
 
-            transcript_name, transcript_biotype = None, None
-            assert len(result) >= 5 and len(result) <= 7, \
+            transcript_name, transcript_biotype, transcript_support_level = None, None, None
+            assert len(result) >= 5 and len(result) <= 8, \
                 "Result is not the expected length: %d" % len(result)
             contig, start, end, strand, gene_id = result[:5]
-            if len(result) == 6:
-                if "transcript_name" in field_names:
-                    transcript_name = result[5]
-                else:
-                    transcript_biotype = result[5]
-            elif len(result) == 7:
-                transcript_name, transcript_biotype = result[5:]
+            if len(result) > 5:
+                extra_field_names = [f for f in optional_field_names if f in field_names]
+                extra_data = dict(zip(extra_field_names, result[5:]))
+                transcript_name = extra_data.get("transcript_name")
+                transcript_biotype = extra_data.get("transcript_biotype")
+                transcript_support_level = extra_data.get("transcript_support_level")
 
             self._transcripts[transcript_id] = Transcript(
                 transcript_id=transcript_id,
@@ -887,6 +887,7 @@ class Genome(Serializable):
                 end=end,
                 strand=strand,
                 biotype=transcript_biotype,
+                support_level=transcript_support_level,
                 gene_id=gene_id,
                 genome=self)
 

--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -869,7 +869,7 @@ class Genome(Serializable):
                 raise ValueError("Transcript not found: %s" % (transcript_id,))
 
             transcript_name, transcript_biotype, transcript_support_level = None, None, None
-            assert len(result) >= 5 and len(result) <= 8, \
+            assert len(result) >= 5 and len(result) <= 5 + len(optional_field_names), \
                 "Result is not the expected length: %d" % len(result)
             contig, start, end, strand, gene_id = result[:5]
             if len(result) > 5:

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -36,6 +36,7 @@ class Transcript(LocusWithGenome):
             end,
             strand,
             biotype,
+            support_level,
             gene_id,
             genome):
         LocusWithGenome.__init__(
@@ -48,6 +49,7 @@ class Transcript(LocusWithGenome):
             genome=genome)
         self.transcript_id = transcript_id
         self.transcript_name = transcript_name
+        self.support_level = support_level
         self.gene_id = gene_id
 
     @property

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -38,7 +38,7 @@ class Transcript(LocusWithGenome):
             biotype,
             gene_id,
             genome,
-            support_level):
+            support_level=None):
         LocusWithGenome.__init__(
             self,
             contig=contig,

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -36,9 +36,9 @@ class Transcript(LocusWithGenome):
             end,
             strand,
             biotype,
-            support_level,
             gene_id,
-            genome):
+            genome,
+            support_level):
         LocusWithGenome.__init__(
             self,
             contig=contig,
@@ -49,8 +49,8 @@ class Transcript(LocusWithGenome):
             genome=genome)
         self.transcript_id = transcript_id
         self.transcript_name = transcript_name
-        self.support_level = support_level
         self.gene_id = gene_id
+        self.support_level = support_level
 
     @property
     def id(self):
@@ -103,6 +103,7 @@ class Transcript(LocusWithGenome):
         state_dict["transcript_id"] = self.transcript_id
         state_dict["transcript_name"] = self.name
         state_dict["gene_id"] = self.gene_id
+        state_dict["support_level"] = self.support_level
         return state_dict
 
     @property

--- a/test/test_transcript_support_level.py
+++ b/test/test_transcript_support_level.py
@@ -9,14 +9,26 @@ from nose.tools import eq_
 from pyensembl import cached_release
 
 def test_transcript_support_level():
+    """ The Transcript Support Level (TSL) is a method to highlight the well-supported and poorly-supported transcript
+        models for users, based on the type and quality of the alignments used to annotate the transcript.
+        In the Ensembl database, it can be assigned to a value 1 through 5, or reported as NA, or missing, or missing
+        completely in older releases. We translate it to an integer value, otherwise to None.
+    """
     ensembl93 = cached_release(93)
     transcript = ensembl93.transcripts_by_name("DDX11L1-202")[0]
-    eq_(transcript.support_level, "1")
-    # for this transcript, the tsl value is missing, and should yield an empty string:
-    transcript = ensembl93.transcripts_by_name("OR4G11P-202")[0]
-    eq_(transcript.support_level, '')
+    eq_(transcript.support_level, 1)
 
-    # transcript_support_level columns was missing in GRCh37 and older releases of GRCh38, and should yield None:
+    # For this transcript, the transcript_support_level value is missing in the database record:
+    transcript = ensembl93.transcripts_by_name("OR4G11P-202")[0]
+    eq_(transcript.support_level, None)
+
+    # Some features are reported as "NA" in Ensembl: those are features like pseudogenes, single exon transcripts,
+    # HLA, T-cell receptor and Ig transcripts that are not analysed in terms of TSL and therefore not given any
+    # of the TSL categories. We translate NA to None as well.
+    transcript = ensembl93.transcripts_by_name("MIR1302-2-201")[0]
+    eq_(transcript.support_level, None)
+
+    # Transcript_support_level column was missing completely in GRCh37 and older releases of GRCh38:
     ensembl77 = cached_release(77)
     transcript = ensembl77.transcripts_by_name("DDX11L1-002")[0]
     eq_(transcript.support_level, None)

--- a/test/test_transcript_support_level.py
+++ b/test/test_transcript_support_level.py
@@ -1,0 +1,22 @@
+"""
+Tests for methods which return collections of transcript IDs that aren't
+converting from some type of name or ID.
+"""
+from __future__ import absolute_import
+
+from nose.tools import eq_
+
+from pyensembl import cached_release
+
+def test_transcript_support_level():
+    ensembl93 = cached_release(93)
+    transcript = ensembl93.transcripts_by_name("DDX11L1-202")[0]
+    eq_(transcript.support_level, "1")
+    # for this transcript, the tsl value is missing, and should yield an empty string:
+    transcript = ensembl93.transcripts_by_name("OR4G11P-202")[0]
+    eq_(transcript.support_level, '')
+
+    # transcript_support_level columns was missing in GRCh37 and older releases of GRCh38, and should yield None:
+    ensembl77 = cached_release(77)
+    transcript = ensembl77.transcripts_by_name("DDX11L1-002")[0]
+    eq_(transcript.support_level, None)


### PR DESCRIPTION
GRCh38 database provides a field called `transcript_support_level` (TSL) for transcript features. This PR adds reading of it as an optional field, and adds a new `support_level` field for `Transcript` object.