### PR TITLE
removing encrypted values from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,9 @@ cache:
   ##  - $HOME/.cache/pyensembl/
 env:
   global:
-    # MHC_BUNDLE_PASS
-    ## Trying to use only publicly available predictors until we can figure
-    ## out how to use encrypted values on Travis with PRs from external forks
-    ## - secure: "B2bLOYhDD1mSH6nBmUVoyoVzO8CsZ/qeduoQ/gq1UqPXyBa5cj8x1hYeYEXMVGH04dq6p5FHKIZoZOOmgtKoemje5enSV8IL2lttASqNvzsiyvy6I4C3r5Ve2H9HMLneDxkarfVVVhG2ZJyO7Y/vGN8STZWX6N3FJfCJ1B5kV5Q="
+    # MHC_BUNDLE_PASS = encrypted value
+    # Won't be available for PRs from external contributors
+    - secure: "B2bLOYhDD1mSH6nBmUVoyoVzO8CsZ/qeduoQ/gq1UqPXyBa5cj8x1hYeYEXMVGH04dq6p5FHKIZoZOOmgtKoemje5enSV8IL2lttASqNvzsiyvy6I4C3r5Ve2H9HMLneDxkarfVVVhG2ZJyO7Y/vGN8STZWX6N3FJfCJ1B5kV5Q="
     - CONDA_ENV="test-environment-$TRAVIS_PYTHON_VERSION"
 addons:
   apt:
@@ -50,15 +49,15 @@ before_install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-
-  # install MHC predictors
-  ## Trying to use only publicly available predictors until we can figure
-  ## out how to use encrypted values on Travis with PRs from external forks
-  ## - git clone https://mhcbundle:$MHC_BUNDLE_PASS@github.com/openvax/netmhc-bundle.git
-  ## - export NETMHC_BUNDLE_HOME=$PWD/netmhc-bundle
-  ## - mkdir tmp
-  ## - export NETMHC_BUNDLE_TMPDIR=$PWD/tmp
-  ## - export PATH=$PATH:$NETMHC_BUNDLE_HOME/bin
+  # install non-public MHC predictors if running within OpenVax org
+  - |
+    if [ -n "$MHC_BUNDLE_PASS" ]; then
+      git clone https://mhcbundle:$MHC_BUNDLE_PASS@github.com/openvax/netmhc-bundle.git;
+      export NETMHC_BUNDLE_HOME=$PWD/netmhc-bundle;
+      mkdir tmp;
+      export NETMHC_BUNDLE_TMPDIR=$PWD/tmp;
+      export PATH=$PATH:$NETMHC_BUNDLE_HOME/bin;
+    fi
   - git clone https://github.com/openvax/openvax-integration-tests.git
 install:
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,21 @@ git:
   # https://github.com/travis-ci/travis-ci/issues/4575
   depth: 10
 cache:
+  # Cache pip installed dependencies
   pip: true
   # cache directory used for Ensembl downloads of GTF and FASTA files
   # along with the indexed db of intervals and ID mappings and pickles
-  # of sequence dictionaries. Also, pip
-  # directories:
-  #  - $HOME/.cache/pyensembl/
+  # of sequence dictionaries.
+  ## ---
+  ## Commenting this out for now due to failure of upload of cached data
+  ## to Travis at the end of build, probably exceeding some storage limit?
+  ##  - $HOME/.cache/pyensembl/
 env:
   global:
     # MHC_BUNDLE_PASS
-    - secure: "B2bLOYhDD1mSH6nBmUVoyoVzO8CsZ/qeduoQ/gq1UqPXyBa5cj8x1hYeYEXMVGH04dq6p5FHKIZoZOOmgtKoemje5enSV8IL2lttASqNvzsiyvy6I4C3r5Ve2H9HMLneDxkarfVVVhG2ZJyO7Y/vGN8STZWX6N3FJfCJ1B5kV5Q="
+    ## Trying to use only publicly available predictors until we can figure
+    ## out how to use encrypted values on Travis with PRs from external forks
+    ## - secure: "B2bLOYhDD1mSH6nBmUVoyoVzO8CsZ/qeduoQ/gq1UqPXyBa5cj8x1hYeYEXMVGH04dq6p5FHKIZoZOOmgtKoemje5enSV8IL2lttASqNvzsiyvy6I4C3r5Ve2H9HMLneDxkarfVVVhG2ZJyO7Y/vGN8STZWX6N3FJfCJ1B5kV5Q="
     - CONDA_ENV="test-environment-$TRAVIS_PYTHON_VERSION"
 addons:
   apt:
@@ -47,11 +52,13 @@ before_install:
   - conda info -a
 
   # install MHC predictors
-  - git clone https://mhcbundle:$MHC_BUNDLE_PASS@github.com/openvax/netmhc-bundle.git
-  - export NETMHC_BUNDLE_HOME=$PWD/netmhc-bundle
-  - mkdir tmp
-  - export NETMHC_BUNDLE_TMPDIR=$PWD/tmp
-  - export PATH=$PATH:$NETMHC_BUNDLE_HOME/bin
+  ## Trying to use only publicly available predictors until we can figure
+  ## out how to use encrypted values on Travis with PRs from external forks
+  ## - git clone https://mhcbundle:$MHC_BUNDLE_PASS@github.com/openvax/netmhc-bundle.git
+  ## - export NETMHC_BUNDLE_HOME=$PWD/netmhc-bundle
+  ## - mkdir tmp
+  ## - export NETMHC_BUNDLE_TMPDIR=$PWD/tmp
+  ## - export PATH=$PATH:$NETMHC_BUNDLE_HOME/bin
   - git clone https://github.com/openvax/openvax-integration-tests.git
 install:
   - >

--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -41,7 +41,7 @@ from .species import (
 )
 from .transcript import Transcript
 
-__version__ = '1.7.0'
+__version__ = '1.7.1'
 
 __all__ = [
     "MemoryCache",


### PR DESCRIPTION
External contributors can't currently submit PRs from forks and have their unit tests run since Travis doesn't expose encrypted values outside of the `openvax` organization. There were some attempts to negotiate a solution in 2014 which seem to have fizzled: https://github.com/travis-ci/travis-ci/issues/1946

So, to re-enable external PRs, I'm dropping our private MHC binding predictors and relying exclusively on MHCflurry, "random" and "iedb-*" predictors. 