### PR TITLE
Implemented comparison on Locus objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,12 @@ before_install:
 install:
   - >
       conda create -q -n $CONDA_ENV python=$TRAVIS_PYTHON_VERSION
-      numpy nose pandas pandoc
+      numpy nose pandas
   - source activate $CONDA_ENV
   # install pysam from conda because I'm having trouble installing Cython
   # for Python 3 on Travis
   - conda install -c bioconda pysam=0.9.0
   - python --version #  make sure we're running the Python version we expect
-  - pip install pypandoc
   - pip install -r requirements.txt
   - pip install .
   - pip install coveralls

--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -41,7 +41,7 @@ from .species import (
 )
 from .transcript import Transcript
 
-__version__ = '1.7.2'
+__version__ = '1.7.3'
 
 __all__ = [
     "MemoryCache",

--- a/pyensembl/exon.py
+++ b/pyensembl/exon.py
@@ -16,6 +16,7 @@ from __future__ import print_function, division, absolute_import
 
 from .locus import Locus
 
+
 class Exon(Locus):
     def __init__(
             self,
@@ -27,17 +28,40 @@ class Exon(Locus):
             gene_name,
             gene_id):
         Locus.__init__(self, contig, start, end, strand)
-        self.id = exon_id
+        self.exon_id = exon_id
         self.gene_name = gene_name
         self.gene_id = gene_id
 
+    @property
+    def id(self):
+        """
+        Alias for exon_id necessary for backward compatibility.
+        """
+        return self.exon_id
+
     def __str__(self):
-        return "Exon(exon_id=%s, gene_name=%s, contig=%s, start=%d, end=%s)" % (
-            self.id, self.gene_name, self.contig, self.start, self.end)
+        return (
+            "Exon(exon_id='%s',"
+            " contig='%s',"
+            " start=%d,"
+            " end=%s,"
+            " strand='%s',"
+            " gene_name='%s',"
+            " gene_id='%s')" % (
+                self.id,
+                self.contig,
+                self.start,
+                self.end,
+                self.strand,
+                self.gene_name,
+                self.gene_id))
 
     def __eq__(self, other):
+        if not isinstance(other, Exon):
+            raise TypeError("Cannot compare %s and %s" % (
+                self.__class__.__name__,
+                other.__class.__name__))
         return (
-            other.__class__ is Exon and
             self.contig == other.contig and
             self.start == other.start and
             self.end == other.end and

--- a/pyensembl/exon.py
+++ b/pyensembl/exon.py
@@ -42,19 +42,19 @@ class Exon(Locus):
     def __str__(self):
         return (
             "Exon(exon_id='%s',"
+            " gene_id='%s',"
+            " gene_name='%s',"
             " contig='%s',"
             " start=%d,"
             " end=%s,"
-            " strand='%s',"
-            " gene_name='%s',"
-            " gene_id='%s')" % (
-                self.id,
+            " strand='%s')") % (
+                self.exon_id,
+                self.gene_id,
+                self.gene_name,
                 self.contig,
                 self.start,
                 self.end,
-                self.strand,
-                self.gene_name,
-                self.gene_id))
+                self.strand)
 
     def __eq__(self, other):
         if not isinstance(other, Exon):

--- a/pyensembl/gene.py
+++ b/pyensembl/gene.py
@@ -57,13 +57,21 @@ class Gene(LocusWithGenome):
         return self.gene_name
 
     def __str__(self):
-        return "Gene(gene_id=%s, gene_name=%s, biotype=%s, location=%s:%d-%d)" % (
+        return (
+            "Gene(gene_id='%s',"
+            " gene_name='%s',"
+            " biotype='%s',"
+            " contig='%s',"
+            " start=%d,"
+            " end=%d, strand='%s', genome='%s')") % (
             self.gene_id,
             self.gene_name,
             self.biotype,
             self.contig,
             self.start,
-            self.end)
+            self.end,
+            self.strand,
+            self.genome.reference_name)
 
     def __eq__(self, other):
         return (

--- a/pyensembl/gene.py
+++ b/pyensembl/gene.py
@@ -18,6 +18,7 @@ from memoized_property import memoized_property
 
 from .locus_with_genome import LocusWithGenome
 
+
 class Gene(LocusWithGenome):
 
     def __init__(

--- a/pyensembl/locus.py
+++ b/pyensembl/locus.py
@@ -64,15 +64,18 @@ class Locus(Serializable):
         self.end = end
 
     def __str__(self):
-        return "Locus(contig=%s, start=%s, end=%s, strand=%s)" % (
+        return "Locus(contig='%s', start=%d, end=%s, strand='%s')" % (
             self.contig, self.start, self.end, self.strand)
 
     def __len__(self):
         return self.end - self.start + 1
 
     def __eq__(self, other):
+        if not isinstance(other, Locus):
+            raise TypeError("Cannot compare %s and %s" % (
+                self.__class__.__name__,
+                other.__class.__name__))
         return (
-            self.__class__ is other.__class__ and
             self.contig == other.contig and
             self.start == other.start and
             self.end == other.end and
@@ -84,7 +87,9 @@ class Locus(Serializable):
 
     def __lt__(self, other):
         if not isinstance(other, Locus):
-            return False
+            raise TypeError("Cannot compare %s and %s" % (
+                self.__class__.__name__,
+                other.__class.__name__))
         return self.to_tuple() < other.to_tuple()
 
     def __le__(self, other):
@@ -92,7 +97,9 @@ class Locus(Serializable):
 
     def __gt__(self, other):
         if not isinstance(other, Locus):
-            return False
+            raise TypeError("Cannot compare %s and %s" % (
+                self.__class__.__name__,
+                other.__class.__name__))
         return self.to_tuple() > other.to_tuple()
 
     def __ge__(self, other):

--- a/pyensembl/locus.py
+++ b/pyensembl/locus.py
@@ -18,6 +18,7 @@ from serializable import Serializable
 
 from .normalization import normalize_chromosome, normalize_strand
 
+
 class Locus(Serializable):
     """
     Base class for any entity which can be localized at a range of positions
@@ -71,12 +72,31 @@ class Locus(Serializable):
 
     def __eq__(self, other):
         return (
-            isinstance(other, Locus) and
+            self.__class__ is other.__class__ and
             self.contig == other.contig and
             self.start == other.start and
             self.end == other.end and
             self.strand == other.strand
         )
+
+    def to_tuple(self):
+        return (self.contig, self.start, self.end, self.strand)
+
+    def __lt__(self, other):
+        if not isinstance(other, Locus):
+            return False
+        return self.to_tuple() < other.to_tuple()
+
+    def __le__(self, other):
+        return (self == other) or (self < other)
+
+    def __gt__(self, other):
+        if not isinstance(other, Locus):
+            return False
+        return self.to_tuple() > other.to_tuple()
+
+    def __ge__(self, other):
+        return (self == other) or (self > other)
 
     def to_dict(self):
         return {

--- a/pyensembl/locus.py
+++ b/pyensembl/locus.py
@@ -64,7 +64,7 @@ class Locus(Serializable):
         self.end = end
 
     def __str__(self):
-        return "Locus(contig='%s', start=%d, end=%s, strand='%s')" % (
+        return "Locus(contig='%s', start=%d, end=%d, strand='%s')" % (
             self.contig, self.start, self.end, self.strand)
 
     def __len__(self):

--- a/pyensembl/locus_with_genome.py
+++ b/pyensembl/locus_with_genome.py
@@ -16,6 +16,7 @@ from __future__ import print_function, division, absolute_import
 
 from .locus import Locus
 
+
 class LocusWithGenome(Locus):
     """
     Common base class for Gene and Transcript to avoid copying

--- a/pyensembl/normalization.py
+++ b/pyensembl/normalization.py
@@ -21,6 +21,7 @@ from typechecks import is_string, is_integer
 # noticable overhead in this instance.
 NORMALIZE_CHROMOSOME_CACHE = {}
 
+
 def normalize_chromosome(c):
     try:
         return NORMALIZE_CHROMOSOME_CACHE[c]
@@ -31,6 +32,7 @@ def normalize_chromosome(c):
         raise TypeError("Chromosome cannot be '%s' : %s" % (c, type(c)))
 
     result = str(c)
+
     if result == "0":
         raise ValueError("Chromosome name cannot be 0")
     elif result == "":
@@ -56,6 +58,7 @@ def normalize_chromosome(c):
     NORMALIZE_CHROMOSOME_CACHE[c] = result
 
     return result
+
 
 def normalize_strand(strand):
     if strand == "+" or strand == "-":

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -19,6 +19,7 @@ from memoized_property import memoized_property
 from .common import memoize
 from .locus_with_genome import LocusWithGenome
 
+
 class Transcript(LocusWithGenome):
     """
     Transcript encompasses the locus, exons, and sequence of a transcript.
@@ -68,12 +69,14 @@ class Transcript(LocusWithGenome):
 
     def __str__(self):
         return (
-            "Transcript(transcript_id=%s,"
-            " name=%s,"
-            " gene_id=%s,"
+            "Transcript(transcript_id='%s',"
+            " name='%s',"
+            " gene_id='%s',"
             " gene_name=%s,"
-            " biotype=%s,"
-            " location=%s:%d-%d)") % (
+            " biotype='%s',"
+            " contig='%s',"
+            " start=%d,"
+            " end=%d)" % (
                 self.transcript_id,
                 self.name,
                 self.gene.id,
@@ -81,7 +84,7 @@ class Transcript(LocusWithGenome):
                 self.biotype,
                 self.contig,
                 self.start,
-                self.end)
+                self.end))
 
     def __len__(self):
         """

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -70,21 +70,21 @@ class Transcript(LocusWithGenome):
     def __str__(self):
         return (
             "Transcript(transcript_id='%s',"
-            " name='%s',"
+            " transcript_name='%s',"
             " gene_id='%s',"
-            " gene_name=%s,"
             " biotype='%s',"
             " contig='%s',"
             " start=%d,"
-            " end=%d)" % (
+            " end=%d, strand='%s', genome='%s')") % (
                 self.transcript_id,
                 self.name,
-                self.gene.id,
-                self.gene.name,
+                self.gene_id,
                 self.biotype,
                 self.contig,
                 self.start,
-                self.end))
+                self.end,
+                self.strand,
+                self.genome.reference_name)
 
     def __len__(self):
         """
@@ -112,6 +112,10 @@ class Transcript(LocusWithGenome):
     @property
     def gene(self):
         return self.genome.gene_by_id(self.gene_id)
+
+    @property
+    def gene_name(self):
+        return self.gene.name
 
     @property
     def exons(self):

--- a/setup.py
+++ b/setup.py
@@ -32,14 +32,6 @@ except IOError as e:
     print("Failed to open %s" % readme_path)
     readme_markdown = ""
 
-try:
-    import pypandoc
-    readme_restructured = pypandoc.convert(readme_markdown, to='rst', format='md')
-except ImportError as e:
-    readme_restructured = readme_markdown
-    print(e)
-    print("Failed to convert %s to reStructuredText" % readme_filename)
-    pass
 
 with open('%s/__init__.py' % package_name, 'r') as f:
     version = re.search(
@@ -84,7 +76,8 @@ if __name__ == '__main__':
             "serializable",
             "tinytimer",
         ],
-        long_description=readme_restructured,
+        long_description=readme_markdown,
+        long_description_content_type='text/markdown',
         packages=[package_name],
         package_data={package_name: ['logging.conf']},
     )

--- a/test/data.py
+++ b/test/data.py
@@ -1,12 +1,14 @@
 import os
 from pyensembl import Locus, Genome
 
+
 def data_path(name):
     """
     Return the absolute path to a file in the test/data directory.
     The name specified should be relative to test/data.
     """
     return os.path.join(os.path.dirname(__file__), "data", name)
+
 
 # mapping of ensembl releases to transcript IDs for FOXP3-001
 FOXP3_001_transcript_id = "ENST00000376207"
@@ -127,6 +129,7 @@ custom_mouse_genome_grcm38_subset = Genome(
     gtf_path_or_url=MOUSE_ENSMUSG00000017167_PATH,
     transcript_fasta_paths_or_urls=[MOUSE_ENSMUSG00000017167_TRANSCRIPT_FASTA_PATH],
     protein_fasta_paths_or_urls=[MOUSE_ENSMUSG00000017167_PROTEIN_FASTA_PATH])
+
 
 def setup_init_custom_mouse_genome():
     """

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -25,11 +25,13 @@ from .data import (
     setup_init_custom_mouse_genome
 )
 
+
 @test_ensembl_releases()
 def test_pickle_ensembl_gene(ensembl_genome):
     gene = ensembl_genome.gene_by_id(TP53_gene_id)
     gene_new = pickle.loads(pickle.dumps(gene))
     eq_(gene, gene_new)
+
 
 @test_ensembl_releases()
 def test_pickle_ensembl_transcript(ensembl_genome):
@@ -47,11 +49,13 @@ def test_pickle_ensembl_exon(ensembl_genome):
     exon_reconstructed = pickle.loads(pickle.dumps(exon))
     eq_(exon, exon_reconstructed)
 
+
 @test_ensembl_releases()
 def test_json_ensembl_gene(ensembl_genome):
     gene = ensembl_genome.gene_by_id(TP53_gene_id)
     gene_reconstructed = Gene.from_json(gene.to_json())
     eq_(gene, gene_reconstructed)
+
 
 @test_ensembl_releases()
 def test_json_ensembl_transcript(ensembl_genome):
@@ -60,6 +64,7 @@ def test_json_ensembl_transcript(ensembl_genome):
     transcript_reconstructed = Transcript.from_json(transcript.to_json())
     eq_(transcript, transcript_reconstructed)
 
+
 @test_ensembl_releases()
 def test_json_ensembl_exon(ensembl_genome):
     gene = ensembl_genome.gene_by_id(TP53_gene_id)
@@ -67,6 +72,7 @@ def test_json_ensembl_exon(ensembl_genome):
     exon = transcript.exons[0]
     exon_reconstructed = Exon.from_json(exon.to_json())
     eq_(exon, exon_reconstructed)
+
 
 @test_ensembl_releases()
 def test_pickle_ensembl_genome(ensembl_genome):
@@ -78,11 +84,13 @@ def test_pickle_ensembl_genome(ensembl_genome):
     eq_(ensembl_genome.release, genome_reconstructed.release)
     eq_(ensembl_genome.species, genome_reconstructed.species)
 
+
 @test_ensembl_releases()
 def test_ensembl_genome_to_dict(ensembl_genome):
     genome_dict = ensembl_genome.to_dict()
     genome_reconstructed = ensembl_genome.__class__.from_dict(genome_dict)
     eq_(ensembl_genome, genome_reconstructed)
+
 
 @test_ensembl_releases()
 def test_ensembl_genome_to_json(ensembl_genome):
@@ -98,16 +106,20 @@ def test_custom_genome_to_json():
     reconstructed = Genome.from_json(json)
     eq_(custom_mouse_genome_grcm38_subset, reconstructed)
 
+
 @with_setup(setup=setup_init_custom_mouse_genome)
 def test_custom_genome_to_dict():
     reconstructed = Genome.from_dict(custom_mouse_genome_grcm38_subset.to_dict())
     eq_(custom_mouse_genome_grcm38_subset, reconstructed)
 
+
 def test_species_to_dict():
     eq_(human, Species.from_dict(human.to_dict()))
 
+
 def test_species_to_json():
     eq_(human, Species.from_json(human.to_json()))
+
 
 def test_species_to_pickle():
     eq_(human, pickle.loads(pickle.dumps(human)))

--- a/test/test_string_representation.py
+++ b/test/test_string_representation.py
@@ -1,0 +1,71 @@
+from pyensembl import Locus, Gene, ensembl_grch37, Transcript, Exon
+from nose.tools import eq_
+
+
+def test_Locus_string_representation():
+    locus = Locus("X", 1000, 1010, "+")
+    string_repr = str(locus)
+    expected = "Locus(contig='X', start=1000, end=1010, strand='+')"
+    eq_(string_repr, expected)
+
+
+def test_Gene_string_representation():
+    gene = Gene(
+        gene_id="ENSG0001", gene_name="CAPITALISM",
+        biotype="protein_coding", contig="Y", start=1, end=5, strand="+",
+        genome=ensembl_grch37)
+    string_repr = str(gene)
+    expected = (
+        "Gene(gene_id='ENSG0001',"
+        " gene_name='CAPITALISM',"
+        " biotype='protein_coding',"
+        " contig='Y',"
+        " start=1, end=5, strand='+', genome='GRCh37')")
+    eq_(string_repr, expected)
+
+
+def test_Transcript_string_representation():
+    transcript = Transcript(
+        transcript_id="ENST0001",
+        transcript_name="CAPITALISM-001",
+        gene_id="ENSG0001",
+        biotype="protein_coding",
+        contig="Y",
+        start=1,
+        end=5,
+        strand="+",
+        genome=ensembl_grch37)
+
+    expected = (
+        "Transcript(transcript_id='ENST0001',"
+        " transcript_name='CAPITALISM-001',"
+        " gene_id='ENSG0001',"
+        " biotype='protein_coding',"
+        " contig='Y',"
+        " start=1,"
+        " end=5, strand='+', genome='GRCh37')"
+    )
+    string_repr = str(transcript)
+    eq_(string_repr, expected)
+
+
+def test_Exon_string_representation():
+    exon = Exon(
+        exon_id="ENSE0001",
+        gene_id="ENSG0001",
+        gene_name="CAPITALISM",
+        contig="Y",
+        start=1,
+        end=5,
+        strand="+")
+
+    expected = (
+        "Exon(exon_id='ENSE0001',"
+        " gene_id='ENSG0001',"
+        " gene_name='CAPITALISM',"
+        " contig='Y',"
+        " start=1,"
+        " end=5, strand='+')"
+    )
+    string_repr = str(exon)
+    eq_(string_repr, expected)

--- a/test/test_transcript_objects.py
+++ b/test/test_transcript_objects.py
@@ -19,6 +19,7 @@ from .data import (
 
 ensembl77 = cached_release(77)
 
+
 def test_transcript_start_codon():
     """
     test_transcript_start_codon : Check that fields Transcript
@@ -26,7 +27,8 @@ def test_transcript_start_codon():
     """
     CTNNBIP1_004_transcript = ensembl77.transcript_by_id(
         CTNNBIP1_004_transcript_id)
-    assert Locus.__eq__(CTNNBIP1_004_locus, CTNNBIP1_004_transcript), \
+
+    assert Locus.__eq__(CTNNBIP1_004_transcript, CTNNBIP1_004_locus), \
         "Expected locus %s but got %s" % (
             CTNNBIP1_004_locus, Locus.__str__(CTNNBIP1_004_transcript))
 
@@ -44,6 +46,7 @@ def test_transcript_start_codon():
     assert start_codon_offset == expected_start_codon_offset, \
         "Incorrect start codon offset, expected %d but got %d" % (
             expected_start_codon_offset, start_codon_offset)
+
 
 def test_transcript_exons():
     """


### PR DESCRIPTION
'gene.exons` does not work on Py3 (https://github.com/openvax/pyensembl/issues/215) due to lack of comparison for `sorted`, fixing this by implementing basic comparison methods on Locus (base class for Exon). 