### PR TITLE
Updated ensembl_release_versions.py

### DIFF
--- a/pyensembl/ensembl_release_versions.py
+++ b/pyensembl/ensembl_release_versions.py
@@ -15,7 +15,7 @@
 from __future__ import print_function, division, absolute_import
 
 MIN_ENSEMBL_RELEASE = 54
-MAX_ENSEMBL_RELEASE = 95
+MAX_ENSEMBL_RELEASE = 97
 
 def check_release_number(release):
     """


### PR DESCRIPTION
Current version does not allow to get versions > 95. This allows access to versions 96 & 97.