### PR TITLE
Fix chrM / MT normalization

### DIFF
--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -42,7 +42,7 @@ from .species import (
 )
 from .transcript import Transcript
 
-__version__ = '1.7.5'
+__version__ = '1.8.0'
 
 __all__ = [
     "MemoryCache",

--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -32,6 +32,7 @@ from .reference_name import (
     which_reference,
     genome_for_reference_name,
 )
+
 from .search import find_nearest_locus
 from .sequence_data import SequenceData
 from .species import (

--- a/pyensembl/normalization.py
+++ b/pyensembl/normalization.py
@@ -38,17 +38,13 @@ def normalize_chromosome(c):
     elif result == "":
         raise ValueError("Chromosome name cannot be empty")
 
-    # only strip off lowercase chr since some of the non-chromosomal
-    # contigs start with "CHR"
-    if result.startswith("chr"):
-        result = result[3:]
-
-    # just in case someone is being lazy, capitalize "M", "MT", X", "Y"
-    result = result.upper()
-
-    # standardize mitochondrial genome to be "MT"
-    if result == "M":
-        result = "MT"
+    if result.startswith("chr") and "_" not in result:
+        # excluding "_" for names like "chrUn_gl000212"
+        # capitalize "chrx" -> "chrX"
+        result = "chr" + result[3:].upper()
+    elif result.isalpha():
+        # capitalize e.g. "x" -> "X"
+        result = result.upper()
 
     # interning strings since the chromosome names probably get constructed
     # or parsed millions of times, can save memory in tight situations

--- a/pyensembl/normalization.py
+++ b/pyensembl/normalization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018. Mount Sinai School of Medicine
+# Copyright (c) 2016-2019. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyensembl/reference_name.py
+++ b/pyensembl/reference_name.py
@@ -56,7 +56,6 @@ def genome_for_reference_name(
     If `allow_older_downloaded_release` is True, and some older releases have
     been downloaded, then return the most recent locally available release.
 
-
     Otherwise, return the newest release of Ensembl (even if its data hasn't
     already been downloaded).
     """

--- a/test/test_locus.py
+++ b/test/test_locus.py
@@ -1,25 +1,29 @@
 from __future__ import absolute_import
 
-from pyensembl.locus import normalize_chromosome, Locus
+from pyensembl.locus import Locus
+from pyensembl.normalization import normalize_chromosome
 
 from nose.tools import assert_raises
 
 def test_normalize_chromosome():
     assert normalize_chromosome("X") == "X"
-    assert normalize_chromosome("chrX") == "X"
+    assert normalize_chromosome("chrX") == "chrX"
+
     assert normalize_chromosome("x") == "X"
+    assert normalize_chromosome("chrx") == "chrX"
 
     assert normalize_chromosome(1) == "1"
     assert normalize_chromosome("1") == "1"
-    assert normalize_chromosome("chr1") == "1"
+    assert normalize_chromosome("chr1") == "chr1"
 
-    assert normalize_chromosome("chrM") == "MT"
-    assert normalize_chromosome("chrMT") == "MT"
-    assert normalize_chromosome("M") == "MT"
+    assert normalize_chromosome("chrM") == "chrM"
+    assert normalize_chromosome("chrMT") == "chrMT"
+    assert normalize_chromosome("M") == "M"
     assert normalize_chromosome("MT") == "MT"
-    assert normalize_chromosome("m") == "MT"
-    assert normalize_chromosome("chrm") == "MT"
+    assert normalize_chromosome("m") == "M"
+    assert normalize_chromosome("chrm") == "chrM"
     assert normalize_chromosome("mt") == "MT"
+    assert normalize_chromosome("chrmt") == "chrMT"
 
     with assert_raises(TypeError):
         normalize_chromosome({"a": "b"})

--- a/test/test_ucsc_gtf.py
+++ b/test/test_ucsc_gtf.py
@@ -53,10 +53,10 @@ def test_ucsc_gencode_genome():
         eq_(gene_uc001aak4.name, None)
         eq_(gene_uc001aak4.biotype, None)
 
-        gene_1_17369 = genome.genes_at_locus(1, 17369)
+        gene_1_17369 = genome.genes_at_locus("chr1", 17369)
         eq_(gene_1_17369[0].id, "uc031tla.1")
 
-        transcript_1_30564 = genome.transcripts_at_locus(1, 30564)
+        transcript_1_30564 = genome.transcripts_at_locus("chr1", 30564)
         eq_(transcript_1_30564[0].id, "uc057aty.1")
 
 def test_ucsc_refseq_gtf():
@@ -102,7 +102,7 @@ def test_ucsc_refseq_genome():
         assert len(transcripts) == 2, \
             "Expected 2 transcripts, got %d: %s" % (
                 len(transcripts), transcripts)
-        genes_at_locus = genome.genes_at_locus(1, 67092176)
+        genes_at_locus = genome.genes_at_locus("chr1", 67092176)
         assert len(genes_at_locus) == 2, \
             "Expected 2 genes at locus chr1:67092176, got %d: %s" % (
                 len(genes_at_locus), genes_at_locus)


### PR DESCRIPTION
In the dark ages of PyEnsembl we needed a quick way to annotate variants from hg19 and GRCh37 using Ensembl reference data. This lead to a dirty chromosome normalization hack where we turn e.g. "chr1" -> "1" and "chrM" -> "MT". 

This was always a little questionable (since the mitochondrial sequences aren't actually the same) but even worse is incorrect for references like GRCh38. 

So, this PR gets rid of two aspects of contig normaliztion: "chr" prefix is now preserved and we don't convert "M" -> "MT" for the mitochondrial genome. 

Fixes: https://github.com/openvax/pyensembl/issues/225

To restore use of Ensembl data for hg19 variants we'll have to make a more local contig conversion option in Varcode. 