### PR TITLE
Fix URL path generation issues for Windows 10 users.

### DIFF
--- a/pyensembl/ensembl_url_templates.py
+++ b/pyensembl/ensembl_url_templates.py
@@ -71,7 +71,6 @@ def make_gtf_url(ensembl_release,
     """
     ensembl_release, species, _ = \
         normalize_release_properties(ensembl_release, species)
-    print(ensembl_release, species)
     subdir = GTF_SUBDIR_TEMPLATE % {
         "release": ensembl_release,
         "species": species


### PR DESCRIPTION
- Remove dependencies for urllib_parse and os.path.join. 
- Remove unused function make_fasta_dna_url. 
- Refactor path generation for remote files to better reflect the folder structure on the Ensembl FTP server.

Fixes #217.