### PR TITLE
Add check .start_codon_complete

### DIFF
--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -234,6 +234,17 @@ class Transcript(LocusWithGenome):
         stop_codons = self._transcript_feature_position_ranges(
             "stop_codon", required=False)
         return len(stop_codons) > 0
+    
+    @memoized_property
+    def start_codon_complete(self):
+        """
+        Does the start codon span 3 genomic positions?
+        """
+        try:
+            pos = self._codon_positions("start_codon")
+        except ValueError:
+            return False
+        return True
 
     @memoized_property
     def start_codon_positions(self):
@@ -397,6 +408,7 @@ class Transcript(LocusWithGenome):
         """
         return (
             self.contains_start_codon and
+            self.start_codon_complete and
             self.contains_stop_codon and
             self.coding_sequence is not None and
             len(self.coding_sequence) % 3 == 0


### PR DESCRIPTION
Using release 69 of Ensembl, I ran into an issue where some transcripts existed which had an annotated start_codon that only spanned two positions (example ENST00000543092).

Because of this, when .complete() was run, self.coding_sequence would hit an error when it tried to determine the _codon_positions:
ValueError: Expected 3 positions for start_codon of ENST00000543092 but got 2

It seems that more recent releases of Ensembl do not have this issue (they no longer list a start_codon for these cases).

To continue using Ensembl 69, I added the additional property .start_codon_complete which catches a _codon_position ValueError and returns False, and added self.start_codon_complete as an additional check in .complete().

Fixes #231 