### PR TITLE
bump ensembl release version

### DIFF
--- a/pyensembl/ensembl_release_versions.py
+++ b/pyensembl/ensembl_release_versions.py
@@ -13,7 +13,7 @@
 from __future__ import print_function, division, absolute_import
 
 MIN_ENSEMBL_RELEASE = 54
-MAX_ENSEMBL_RELEASE = 104
+MAX_ENSEMBL_RELEASE = 105
 
 def check_release_number(release):
     """


### PR DESCRIPTION
105 is the latest release, while 104 is the currently enforced upper bound in the library.