### PR TITLE
Add pandas>=1.3.5 as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ gtfparse>=1.3.0,<2.0.0
 serializable
 nose>=1.3.3
 pylint>=1.4.4
+pandas>=1.3.5


### PR DESCRIPTION
Pandas needed when running pyensembl install and will break if lower than this version.