### PR TITLE
Update species.py

### DIFF
--- a/pyensembl/species.py
+++ b/pyensembl/species.py
@@ -303,7 +303,7 @@ guinea_pig = Species.register(
 
 pig = Species.register(
     latin_name="sus_scrofa",
-    synonyms=["pig"],
+    synonyms=["pok",],
     reference_assemblies={"Sscrofa11.1": (75, MAX_ENSEMBL_RELEASE)},
 )
 


### PR DESCRIPTION
Commit message: Change pig synonym to pork to avoid error

In the Species.register function call, replace the 'pig' synonym with 'pork' to prevent the ValueError raised due to synonym conflict.