### PR TITLE
Update numpy to >=2.0.0,<3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "gtfparse>=2.5.0,<3.0.0",
     "serializable>=0.2.1,<1.0.0",
     "numpy>=2.0.0,<3.0.0",
-    "pyarrow>=16.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "tinytimer>=0.0.0,<1.0.0",
     "gtfparse>=2.5.0,<3.0.0",
     "serializable>=0.2.1,<1.0.0",
-    "numpy<2",
+    "numpy>=2.0.0,<3.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "datacache>=1.4.0,<2.0.0",
     "memoized-property>=1.0.2",
     "tinytimer>=0.0.0,<1.0.0",
-    "gtfparse>=2.5.0,<3.0.0",
+    "gtfparse>=2.6.0,<3.0.0",
     "serializable>=0.2.1,<1.0.0",
     "numpy>=2.0.0,<3.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "gtfparse>=2.5.0,<3.0.0",
     "serializable>=0.2.1,<1.0.0",
     "numpy>=2.0.0,<3.0.0",
+    "pyarrow>=16.0.0",
 ]
 
 [project.scripts]

--- a/tests/test_build_system.py
+++ b/tests/test_build_system.py
@@ -70,9 +70,9 @@ def test_dependencies_correct():
         "datacache>=1.4.0,<2.0.0",
         "memoized-property>=1.0.2",
         "tinytimer>=0.0.0,<1.0.0",
-        "gtfparse>=2.5.0,<3.0.0",
+        "gtfparse>=2.6.0,<3.0.0",
         "serializable>=0.2.1,<1.0.0",
-        "numpy<2",
+        "numpy>=2.0.0,<3.0.0",
     }
 
     actual_deps = set(config["project"]["dependencies"])


### PR DESCRIPTION
## Summary
- Update numpy dependency from `<2` to `>=2.0.0,<3.0.0` in pyproject.toml
- Bump version to 2.6.0

## Motivation
numpy 2.x has been available since June 2024. This update is part of a coordinated effort across the openvax ecosystem to modernize numpy support. numpy 2.0.x supports Python 3.9+, which is compatible with pyensembl's `requires-python = ">=3.9"`.

## Test plan
- [ ] CI passes on Python 3.9, 3.10, 3.11
- [ ] No deprecated numpy API usage (np.bool, np.int, np.float, etc.)