### PR TITLE
Fix argparse compatibility with Python 3.14

### DIFF
--- a/pyensembl/shell.py
+++ b/pyensembl/shell.py
@@ -69,9 +69,7 @@ parser.add_argument(
 )
 
 
-root_group = parser.add_mutually_exclusive_group()
-
-release_group = root_group.add_argument_group()
+release_group = parser.add_argument_group("Ensembl release options")
 release_group.add_argument(
     "--release",
     type=int,
@@ -93,7 +91,7 @@ release_group.add_argument(
     help="URL and directory to use instead of the default Ensembl FTP server",
 )
 
-path_group = root_group.add_argument_group()
+path_group = parser.add_argument_group("Custom genome options")
 
 path_group.add_argument(
     "--reference-name",

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.1"
+__version__ = "2.6.2"
 
 def print_version():
     print(f"v{__version__}")


### PR DESCRIPTION
## Summary
- Python 3.14 removed support for nesting `add_argument_group()` inside `add_mutually_exclusive_group()`, which broke the CLI
- The mutual exclusivity between release args and custom path args was already enforced in application code (`collect_selected_genomes`), so the argparse nesting was a no-op
- Replaced with plain argument groups on the parser, which also improves `--help` output with labeled sections
- Bumps version to 2.6.2

Fixes #318

## Test plan
- CI should pass on all existing Python versions (3.9-3.12)
- `pyensembl --help` displays properly organized argument groups