### PR TITLE
Relax HLA-A locus tests for POLR1HASP overlap (Ensembl 114)

### DIFF
--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.3"
+__version__ = "2.6.4"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_gene_ids.py
+++ b/tests/test_gene_ids.py
@@ -15,17 +15,18 @@ ensembl77 = cached_release(77, "human")
 
 
 def test_gene_ids_grch38_hla_a():
-    # chr6:29,945,884  is a position for HLA-A
-    # Gene ID = ENSG00000206503
-    # based on:
+    # chr6:29,945,884 is a position for HLA-A (ENSG00000206503).
+    # Ensembl release 114 introduced overlapping gene POLR1HASP
+    # (ENSG00000293508) at the same locus, so accept either HLA-A alone
+    # or the HLA-A + POLR1HASP pair.
     # http://useast.ensembl.org/Homo_sapiens/Gene/
     # Summary?db=core;g=ENSG00000206503;r=6:29941260-29945884
-    ids = ensembl_grch38.gene_ids_at_locus(6, 29945884)
-    expected = "ENSG00000206503"
-    assert ids == ["ENSG00000206503"], "Expected HLA-A, gene ID = %s, got: %s" % (
-        expected,
-        ids,
-    )
+    ids = set(ensembl_grch38.gene_ids_at_locus(6, 29945884))
+    assert "ENSG00000206503" in ids, "Expected HLA-A (ENSG00000206503), got: %s" % (ids,)
+    if len(ids) > 1:
+        assert ids == {"ENSG00000206503", "ENSG00000293508"}, (
+            "Expected HLA-A alone or HLA-A + POLR1HASP, got: %s" % (ids,)
+        )
 
 
 def test_gene_ids_of_gene_name_hla_grch38():

--- a/tests/test_gene_names.py
+++ b/tests/test_gene_names.py
@@ -34,12 +34,17 @@ def test_all_gene_names(genome):
 
 
 def test_gene_names_at_locus_grch38_hla_a():
-    # chr6:29,945,884  is a position for HLA-A
-    # based on:
+    # chr6:29,945,884 is a position for HLA-A. Ensembl release 114
+    # introduced overlapping gene POLR1HASP at the same locus, so accept
+    # either HLA-A alone or the HLA-A + POLR1HASP pair.
     # http://useast.ensembl.org/Homo_sapiens/Gene/
     # Summary?db=core;g=ENSG00000206503;r=6:29941260-29945884
-    names = grch38.gene_names_at_locus(6, 29945884)
-    assert names == ["HLA-A"], "Expected gene name HLA-A, got: %s" % (names,)
+    names = set(grch38.gene_names_at_locus(6, 29945884))
+    assert "HLA-A" in names, "Expected gene name HLA-A, got: %s" % (names,)
+    if len(names) > 1:
+        assert names == {"HLA-A", "POLR1HASP"}, (
+            "Expected HLA-A alone or HLA-A + POLR1HASP, got: %s" % (names,)
+        )
 
 
 @run_multiple_genomes()


### PR DESCRIPTION
## Summary
- Ensembl release 114 introduced a new gene POLR1HASP (ENSG00000293508) overlapping HLA-A at chr6:29,945,884. The two locus tests asserted a single-element list and now fail on any local cache at release 114 or later. CI didn't catch this because it pins release 93 from `openvax/ensembl-data`.
- Tests now require HLA-A to be present and, if any additional gene is returned, constrain the set to exactly `{HLA-A, POLR1HASP}`.
- Bumps version to 2.6.4 so this ships (2.6.3 was merged but never reached PyPI because of the same local test failures).

## Test plan
- [x] `pytest tests/test_gene_ids.py::test_gene_ids_grch38_hla_a` passes locally against Ensembl 114 cache.
- [x] `pytest tests/test_gene_names.py::test_gene_names_at_locus_grch38_hla_a` passes locally against Ensembl 114 cache.
- [ ] Full CI green across Python 3.9–3.12 (exercises release 93 — should still pass since HLA-A alone is accepted).