### PR TITLE
Fix #286: protein_ids_at_locus queries CDS feature

### DIFF
--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -589,7 +589,7 @@ class Genome(Serializable):
     def protein_ids_at_locus(self, contig, position, end=None, strand=None):
         return self.db.distinct_column_values_at_locus(
             column="protein_id",
-            feature="transcript",
+            feature="CDS",
             contig=contig,
             position=position,
             end=end,

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.4"
+__version__ = "2.6.5"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_transcript_ids.py
+++ b/tests/test_transcript_ids.py
@@ -60,3 +60,19 @@ def test_transcript_id_of_protein_id_CCR2():
     # Ensembl release 104, GRCh38.p13
     transcript_id = grch38.transcript_id_of_protein_id("ENSP00000399285")
     eq_("ENST00000445132", transcript_id)
+
+
+def test_protein_ids_at_locus_grch38_hla_a():
+    # Regression test for https://github.com/openvax/pyensembl/issues/286:
+    # protein_ids_at_locus previously queried the "transcript" feature,
+    # which stores an empty protein_id, so results were a list of empty
+    # strings instead of real protein IDs.
+    # chr6:29,942,555 falls inside the first CDS of HLA-A transcripts.
+    protein_ids = set(grch38.protein_ids_at_locus(6, 29942555))
+    assert protein_ids, "Expected non-empty protein IDs at HLA-A CDS locus"
+    assert "" not in protein_ids, (
+        "protein_ids_at_locus should not return empty strings: %s" % (protein_ids,)
+    )
+    assert "ENSP00000365998" in protein_ids, (
+        "Expected HLA-A protein ENSP00000365998 at locus, got: %s" % (protein_ids,)
+    )


### PR DESCRIPTION
## Summary
- `protein_ids_at_locus` passed `feature="transcript"` to the locus query, but `protein_id` is only populated on CDS rows, so it returned a list of empty strings (one per overlapping transcript) instead of real protein IDs. See #286.
- Every other `protein_id` query in the codebase (`gene_id_of_protein_id`, `transcript_id_of_protein_id`, `protein_ids()`) already uses `feature="CDS"`. One-line fix to match.
- Adds regression test at an HLA-A CDS locus.
- Bumps to 2.6.5.

Closes #286.

## Test plan
- [x] `pytest tests/test_transcript_ids.py` passes locally.
- [ ] CI green on Python 3.9–3.12.