### PR TITLE
Fix #176: coding_sequence_position_ranges now includes stop codon

### DIFF
--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -16,6 +16,24 @@ from .common import memoize
 from .locus_with_genome import LocusWithGenome
 
 
+def _merge_ranges(ranges):
+    """
+    Sort [(start, end)] inclusive-inclusive ranges and merge any that are
+    adjacent or overlapping (end+1 == next start).
+    """
+    if not ranges:
+        return []
+    ordered = sorted(ranges)
+    merged = [ordered[0]]
+    for start, end in ordered[1:]:
+        prev_start, prev_end = merged[-1]
+        if start <= prev_end + 1:
+            merged[-1] = (prev_start, max(prev_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
 class Transcript(LocusWithGenome):
     """
     Transcript encompasses the locus, exons, and sequence of a transcript.
@@ -388,9 +406,15 @@ class Transcript(LocusWithGenome):
     def coding_sequence_position_ranges(self):
         """
         Return absolute chromosome position ranges for CDS fragments
-        of this transcript
+        of this transcript, including the stop codon (which Ensembl
+        encodes as a separate feature from the CDS).
         """
-        return self._transcript_feature_position_ranges("CDS")
+        ranges = list(self._transcript_feature_position_ranges("CDS"))
+        if self.contains_stop_codon:
+            ranges.extend(
+                self._transcript_feature_position_ranges("stop_codon", required=False)
+            )
+        return _merge_ranges(ranges)
 
     @memoized_property
     def complete(self):

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.5"
+__version__ = "2.6.6"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_transcript_sequences.py
+++ b/tests/test_transcript_sequences.py
@@ -17,3 +17,21 @@ def test_transcript_sequence_ensembl_grch38():
     eq_(seq, expected)
     # now try via a Transcript object
     eq_(grch38.transcript_by_id("ENST00000448914").sequence, expected)
+
+
+def test_coding_sequence_matches_position_ranges():
+    # Regression test for https://github.com/openvax/pyensembl/issues/176:
+    # len(coding_sequence) used to exceed the total length of
+    # coding_sequence_position_ranges by exactly 3 because Ensembl's CDS
+    # feature excludes the stop codon while coding_sequence includes it.
+    for transcript_id in [
+        "ENST00000311936",
+        "ENST00000371085",
+        "ENST00000275493",
+    ]:
+        transcript = grch38.transcript_by_id(transcript_id)
+        cds_length = len(transcript.coding_sequence)
+        ranges_length = sum(
+            end - start + 1 for (start, end) in transcript.coding_sequence_position_ranges
+        )
+        eq_(cds_length, ranges_length)


### PR DESCRIPTION
## Summary
- `len(Transcript.coding_sequence)` exceeded the total length of `coding_sequence_position_ranges` by exactly 3 for every complete transcript because Ensembl GTF writes the stop codon as a separate `stop_codon` feature instead of part of the CDS — while `coding_sequence` is computed from start_codon to stop_codon spliced offsets. See #176.
- `coding_sequence_position_ranges` now concatenates the CDS ranges with the stop codon ranges and merges adjacent/overlapping intervals via a new `_merge_ranges` helper (module-private). Transcripts without a stop codon are unchanged.
- Regression test covers the three transcripts from the original bug report (`ENST00000311936`, `ENST00000371085`, `ENST00000275493`) — `len(coding_sequence)` now equals the sum of range lengths.
- Bumps to 2.6.6.

Closes #176.

## Test plan
- [x] `pytest tests/test_transcript_sequences.py` passes.
- [x] Full non-HLA-A suite passes locally (118 tests, no regressions).
- [ ] CI green on Python 3.9–3.12.