### PR TITLE
Fix Transcript.exons crash when GTF lacks exon_id attribute

### DIFF
--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -13,6 +13,7 @@
 from memoized_property import memoized_property
 
 from .common import memoize
+from .exon import Exon
 from .locus_with_genome import LocusWithGenome
 
 
@@ -141,23 +142,25 @@ class Transcript(LocusWithGenome):
     def exons(self):
         # need to look up exon_number alongside ID since each exon may
         # appear in multiple transcripts and have a different exon number
-        # in each transcript
-        columns = ["exon_number", "exon_id"]
-        exon_numbers_and_ids = self.db.query(
+        # in each transcript.
+        # Older or non-Ensembl GTFs may omit the exon_id attribute, in
+        # which case we build Exon objects directly from the exon row
+        # and synthesize a stable per-transcript ID.
+        has_exon_id = self.db.column_exists("exon", "exon_id")
+        if has_exon_id:
+            columns = ["exon_number", "exon_id"]
+        else:
+            columns = ["exon_number", "seqname", "start", "end", "strand"]
+        rows = self.db.query(
             columns, filter_column="transcript_id", filter_value=self.id, feature="exon"
         )
 
         # fill this list in its correct order (by exon_number) by using
         # the exon_number as a 1-based list offset
-        exons = [None] * len(exon_numbers_and_ids)
+        exons = [None] * len(rows)
 
-        for exon_number, exon_id in exon_numbers_and_ids:
-            exon = self.genome.exon_by_id(exon_id)
-            if exon is None:
-                raise ValueError(
-                    "Missing exon %s for transcript %s" % (exon_number, self.id)
-                )
-            exon_number = int(exon_number)
+        for row in rows:
+            exon_number = int(row[0])
             if exon_number < 1:
                 raise ValueError("Invalid exon number: %s" % exon_number)
             elif exon_number > len(exons):
@@ -166,9 +169,27 @@ class Transcript(LocusWithGenome):
                     % (exon_number, len(exons))
                 )
 
+            if has_exon_id:
+                exon_id = row[1]
+                exon = self.genome.exon_by_id(exon_id)
+                if exon is None:
+                    raise ValueError(
+                        "Missing exon %s for transcript %s" % (exon_number, self.id)
+                    )
+            else:
+                _, seqname, start, end, strand = row
+                exon = Exon(
+                    exon_id="%s_exon_%d" % (self.id, exon_number),
+                    contig=seqname,
+                    start=start,
+                    end=end,
+                    strand=strand,
+                    gene_name=self.gene_name,
+                    gene_id=self.gene_id,
+                )
+
             # exon_number is 1-based, convert to list index by subtracting 1
-            exon_idx = exon_number - 1
-            exons[exon_idx] = exon
+            exons[exon_number - 1] = exon
         return exons
 
     # possible annotations associated with transcripts

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.6"
+__version__ = "2.6.7"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_ucsc_gtf.py
+++ b/tests/test_ucsc_gtf.py
@@ -53,6 +53,51 @@ def test_ucsc_gencode_genome():
         eq_(transcript_1_30564[0].id, "uc057aty.1")
 
 
+def test_transcript_exons_without_exon_id():
+    """
+    Regression test: older Ensembl releases (e.g. release 54) and other
+    GTFs omit the exon_id attribute while still providing exon_number.
+    Transcript.exons previously raised
+    sqlite3.OperationalError: no such column: exon_id; it now falls back
+    to building Exon objects directly from the exon row with a
+    synthesized per-transcript ID.
+    """
+    import os
+
+    with TemporaryDirectory() as tmpdir:
+        gtf_path = os.path.join(tmpdir, "no_exon_id.gtf")
+        with open(gtf_path, "w") as f:
+            # minimal Ensembl-style GTF: transcript + 2 ordered exons,
+            # with exon_number but no exon_id (as in Ensembl release 54)
+            f.write(
+                '1\ttest\ttranscript\t100\t500\t.\t+\t.\t'
+                'gene_id "G1"; transcript_id "T1"; gene_name "FN1";\n'
+                '1\ttest\texon\t100\t200\t.\t+\t.\t'
+                'gene_id "G1"; transcript_id "T1"; exon_number "1"; gene_name "FN1";\n'
+                '1\ttest\texon\t300\t500\t.\t+\t.\t'
+                'gene_id "G1"; transcript_id "T1"; exon_number "2"; gene_name "FN1";\n'
+            )
+        genome = Genome(
+            reference_name="GRCh38",
+            annotation_name="no_exon_id_test",
+            gtf_path_or_url=gtf_path,
+            cache_directory_path=tmpdir,
+        )
+        genome.index()
+        assert not genome.db.column_exists("exon", "exon_id"), (
+            "Test fixture unexpectedly has exon_id — update this test"
+        )
+        transcript = genome.transcript_by_id("T1")
+        exons = transcript.exons
+        eq_(len(exons), 2)
+        eq_(exons[0].id, "T1_exon_1")
+        eq_(exons[0].start, 100)
+        eq_(exons[0].end, 200)
+        eq_(exons[1].id, "T1_exon_2")
+        eq_(exons[1].start, 300)
+        eq_(exons[1].end, 500)
+
+
 def test_ucsc_refseq_gtf():
     """
     Test GTF object with a small RefSeq GTF file downloaded from


### PR DESCRIPTION
## Summary
- Some GTFs (Ensembl release 54 and earlier, plus non-Ensembl GTFs) omit the `exon_id` attribute. pyensembl's installer already treats that column as optional (see \`database.py:134\`), but \`Transcript.exons\` still unconditionally `SELECT`ed `exon_id`, so any call on such a genome crashed with:

  ```
  sqlite3.OperationalError: no such column: exon_id
  ```

  This was hit from pirlygenes: FN1 tests call \`transcript.exons\` and the local pyensembl cache (old release) has the exon table without the exon_id column.
- \`Transcript.exons\` now checks \`db.column_exists("exon", "exon_id")\` and falls back to constructing Exon objects directly from the exon row, with a synthesized per-transcript ID of the form \`\"<transcript_id>_exon_<n>\"\`.
- Exon objects returned from the fallback path carry the real contig/start/end/strand/gene coordinates from the GTF; only the id is synthetic.
- Regression test builds a minimal Ensembl-style GTF with \`exon_number\` but no \`exon_id\` and verifies exon ordering and synthesized IDs.
- Bumps to 2.6.7.

## Test plan
- [x] New \`test_transcript_exons_without_exon_id\` passes.
- [x] Full local suite (120 tests excluding HLA-A data-drift ones) passes.
- [ ] CI green on Python 3.9–3.12 (exercises the normal path — release 75/77/93 GTFs all have exon_id).