### PR TITLE
Fix #297: tolerate parenthetical suffix in transcript_support_level

### DIFF
--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -29,6 +29,24 @@ from .sequence_data import SequenceData
 from .transcript import Transcript
 
 
+def _parse_transcript_support_level(value):
+    """
+    Coerce a raw ``transcript_support_level`` attribute into an int or None.
+
+    Recent Ensembl releases append text such as
+    ``"1 (assigned to previous version 5)"`` after the numeric TSL, and
+    older or missing entries can be ``None`` or the literal string ``"NA"``.
+    Keep only the leading whitespace-separated token and return it as an
+    int when it is a digit, otherwise None.
+    """
+    if not value:
+        return None
+    leading = value.split()[0] if value.split() else None
+    if leading and leading.isdigit():
+        return int(leading)
+    return None
+
+
 class Genome(Serializable):
     """
     Bundles together the genomic annotation and sequence data associated with
@@ -896,11 +914,9 @@ class Genome(Serializable):
                 extra_data = dict(zip(extra_field_names, result[5:]))
                 transcript_name = extra_data.get("transcript_name")
                 transcript_biotype = extra_data.get("transcript_biotype")
-                tsl = extra_data.get("transcript_support_level")
-                if not tsl or tsl == "NA":
-                    tsl = None
-                else:
-                    tsl = int(tsl)
+                tsl = _parse_transcript_support_level(
+                    extra_data.get("transcript_support_level")
+                )
 
             self._transcripts[transcript_id] = Transcript(
                 transcript_id=transcript_id,

--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -41,7 +41,8 @@ def _parse_transcript_support_level(value):
     """
     if not value:
         return None
-    leading = value.split()[0] if value.split() else None
+    tokens = value.split()
+    leading = tokens[0] if tokens else None
     if leading and leading.isdigit():
         return int(leading)
     return None

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.7"
+__version__ = "2.6.8"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_transcript_support_level.py
+++ b/tests/test_transcript_support_level.py
@@ -7,6 +7,23 @@ from __future__ import absolute_import
 from .common import eq_
 
 from pyensembl import cached_release
+from pyensembl.genome import _parse_transcript_support_level
+
+
+def test_parse_transcript_support_level_values():
+    # Recent Ensembl releases append parenthetical text to the TSL; we should
+    # still recover the leading integer. See openvax/pyensembl#297.
+    eq_(_parse_transcript_support_level("1 (assigned to previous version 5)"), 1)
+    eq_(_parse_transcript_support_level("3 (assigned to previous version 12)"), 3)
+    # Plain numeric strings still work.
+    eq_(_parse_transcript_support_level("1"), 1)
+    eq_(_parse_transcript_support_level("5"), 5)
+    # Missing / NA / junk values collapse to None.
+    eq_(_parse_transcript_support_level(None), None)
+    eq_(_parse_transcript_support_level(""), None)
+    eq_(_parse_transcript_support_level("NA"), None)
+    eq_(_parse_transcript_support_level("NA (something)"), None)
+    eq_(_parse_transcript_support_level("   "), None)
 
 
 def test_transcript_support_level():


### PR DESCRIPTION
## Summary
- Recent Ensembl releases may emit `transcript_support_level "1 (assigned to previous version 5)"`. `Genome.transcript_by_id` previously called `int(tsl)` directly on that raw string, which crashes unless `gtfparse` is silently splitting all attributes on whitespace — a workaround that mangles any other attribute that legitimately contains an internal space.
- Move the coercion into a small helper `_parse_transcript_support_level` that keeps only the leading whitespace-separated token, returns an int when numeric, and returns `None` for missing / `NA` / non-numeric values. This paves the way for dropping the whitespace-split workaround in `gtfparse`.

Fixes #297.

## Test plan
- [x] Added `test_parse_transcript_support_level_values` covering parenthetical suffix, plain numbers, and `None` / `""` / `"NA"` / whitespace — passes locally.
- [x] `ruff check` clean on touched files.
- [ ] Existing `test_transcript_support_level` (requires Ensembl release 93 download) remains unchanged; rely on CI.