### PR TITLE
Fix #280: distance_to_locus supports ignore_strand for cross-strand distances

### DIFF
--- a/pyensembl/locus.py
+++ b/pyensembl/locus.py
@@ -199,10 +199,15 @@ class Locus(Serializable):
         else:
             return 0
 
-    def distance_to_locus(self, other):
-        if not self.can_overlap(other.contig, other.strand):
-            # if two loci are on different contigs or strands,
-            # can't compute a distance between them
+    def distance_to_locus(self, other, ignore_strand=False):
+        """
+        Distance between two loci. Returns infinity for loci on different
+        contigs, and (by default) for loci on opposite strands of the same
+        contig. Pass ``ignore_strand=True`` to compute a strand-invariant
+        distance between loci on the same contig.
+        """
+        strand = None if ignore_strand else other.strand
+        if not self.can_overlap(other.contig, strand):
             return float("inf")
         return self.distance_to_interval(other.start, other.end)
 

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.9"
+__version__ = "2.6.10"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_locus.py
+++ b/tests/test_locus.py
@@ -158,3 +158,14 @@ def test_locus_distance():
     inf = float("inf")
     assert locus_chr1_10_20_pos.distance_to_locus(locus_chr2_21_25_pos) == inf
     assert locus_chr1_10_20_pos.distance_to_locus(locus_chr1_21_25_neg) == inf
+
+    # ignore_strand=True treats opposite-strand loci on the same contig as
+    # measurable, but still returns inf across contigs.
+    assert (
+        locus_chr1_10_20_pos.distance_to_locus(locus_chr1_21_25_neg, ignore_strand=True)
+        == 1
+    )
+    assert (
+        locus_chr1_10_20_pos.distance_to_locus(locus_chr2_21_25_pos, ignore_strand=True)
+        == inf
+    )


### PR DESCRIPTION
## Summary
- Adds an `ignore_strand=False` keyword to `Locus.distance_to_locus` so callers can opt into a strand-invariant distance instead of getting `inf` when two loci are on opposite strands of the same contig.
- Default behavior is unchanged: `inf` for different contigs, and `inf` for opposite strands unless the caller opts in.
- Bumps version to 2.6.10.

Closes #280.

## Test plan
- [x] `pytest tests/test_locus.py`
- [x] `./lint.sh`
- [x] CI on PR