### PR TITLE
Fix #260: add Locus.overlap_length helper

### DIFF
--- a/pyensembl/locus.py
+++ b/pyensembl/locus.py
@@ -228,6 +228,18 @@ class Locus(Serializable):
             other_locus.contig, other_locus.start, other_locus.end, other_locus.strand
         )
 
+    def overlap_length(self, other, ignore_strand=False):
+        """
+        Number of overlapping base positions between this locus and ``other``.
+        Returns 0 when the loci do not overlap, are on different contigs, or
+        (by default) are on opposite strands. Pass ``ignore_strand=True`` to
+        count overlap regardless of strand.
+        """
+        strand = None if ignore_strand else other.strand
+        if not self.can_overlap(other.contig, strand):
+            return 0
+        return max(0, min(self.end, other.end) - max(self.start, other.start) + 1)
+
     def contains(self, contig, start, end, strand=None):
         return (
             self.can_overlap(contig, strand) and start >= self.start and end <= self.end

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.10"
+__version__ = "2.6.11"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_locus.py
+++ b/tests/test_locus.py
@@ -169,3 +169,23 @@ def test_locus_distance():
         locus_chr1_10_20_pos.distance_to_locus(locus_chr2_21_25_pos, ignore_strand=True)
         == inf
     )
+
+
+def test_locus_overlap_length():
+    locus = Locus("1", 10, 20, "+")
+    # full containment
+    assert locus.overlap_length(Locus("1", 10, 20, "+")) == 11
+    # partial overlap (positions 15..20)
+    assert locus.overlap_length(Locus("1", 15, 30, "+")) == 6
+    # locus fully contains other
+    assert locus.overlap_length(Locus("1", 12, 15, "+")) == 4
+    # single-base overlap at the boundary
+    assert locus.overlap_length(Locus("1", 20, 25, "+")) == 1
+    # adjacent but non-overlapping
+    assert locus.overlap_length(Locus("1", 21, 30, "+")) == 0
+    # different contig
+    assert locus.overlap_length(Locus("2", 10, 20, "+")) == 0
+    # opposite strand: 0 by default, full overlap with ignore_strand=True
+    other_neg = Locus("1", 10, 20, "-")
+    assert locus.overlap_length(other_neg) == 0
+    assert locus.overlap_length(other_neg, ignore_strand=True) == 11


### PR DESCRIPTION
## Summary
- Adds `Locus.overlap_length(other, ignore_strand=False)` returning the number of overlapping base positions between two loci. Mirrors the contig/strand handling of `distance_to_locus` and returns 0 when the loci are disjoint, on different contigs, or on opposite strands.
- Bumps version to 2.6.11.

Closes #260.

## Test plan
- [x] `pytest tests/test_locus.py`
- [x] `./lint.sh`
- [x] CI on PR