### PR TITLE
Fix #296: add 'pyensembl available' CLI action

### DIFF
--- a/pyensembl/shell.py
+++ b/pyensembl/shell.py
@@ -147,13 +147,16 @@ parser.add_argument(
         "delete-all-files",
         "delete-index-files",
         "list",
+        "available",
     ),
     help=(
         '"install" will download and index any data that is  not '
         'currently downloaded or indexed. "delete-all-files" will delete all data '
         'associated with a genome annotation. "delete-index-files" deletes '
         "all files other than the original GTF and FASTA files for a genome. "
-        '"list" will show you all installed Ensembl genomes.'
+        '"list" will show you all installed Ensembl genomes. '
+        '"available" prints every species and the Ensembl release ranges '
+        "supported by pyensembl."
     ),
 )
 
@@ -249,6 +252,25 @@ def collect_selected_genomes(args):
         return all_combinations_of_ensembl_genomes(args)
 
 
+def format_available_species():
+    """
+    Build the multi-line string printed by the "available" action: every
+    registered species followed by its supported Ensembl release ranges,
+    grouped by reference assembly.
+    """
+    lines = []
+    for latin_name in sorted(Species._latin_names_to_species):
+        species = Species._latin_names_to_species[latin_name]
+        if species.synonyms:
+            synonyms = ",".join(species.synonyms)
+            lines.append("* %s (%s):" % (latin_name, synonyms))
+        else:
+            lines.append("* %s:" % latin_name)
+        for assembly, (start, end) in species.reference_assemblies.items():
+            lines.append("  * %s: (%d, %d)" % (assembly, start, end))
+    return "\n".join(lines)
+
+
 def run():
     args = parser.parse_args()
     if args.action == "list":
@@ -261,6 +283,8 @@ def run():
             filepaths = genome.required_local_files()
             directories = {os.path.split(path)[0] for path in filepaths}
             print("-- %s: %s" % (genome, ", ".join(directories)))
+    elif args.action == "available":
+        print(format_available_species())
     else:
         genomes = collect_selected_genomes(args)
 

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.11"
+__version__ = "2.6.12"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,4 +1,8 @@
-from pyensembl.shell import parser, all_combinations_of_ensembl_genomes
+from pyensembl.shell import (
+    all_combinations_of_ensembl_genomes,
+    format_available_species,
+    parser,
+)
 from .common import eq_
 
 
@@ -9,3 +13,20 @@ def test_genome_selection_grch38():
     genome = genomes[0]
     eq_(genome.species.latin_name, "homo_sapiens")
     eq_(genome.release, 100)
+
+
+def test_available_action_parses():
+    args = parser.parse_args(["available"])
+    eq_(args.action, "available")
+
+
+def test_format_available_species_includes_human_and_assemblies():
+    output = format_available_species()
+    # human is registered with common name "human" and three reference assemblies
+    assert "homo_sapiens" in output
+    assert "human" in output
+    assert "GRCh38" in output
+    assert "GRCh37" in output
+    # mouse should also appear
+    assert "mus_musculus" in output
+    assert "GRCm38" in output


### PR DESCRIPTION
## Summary
- Adds an `available` action to the `pyensembl` CLI that prints every registered species with its supported Ensembl release ranges (grouped by reference assembly). Closes #296.
- Pure read of the in-process `Species` registry — no downloads, no DB.
- Bumps version to 2.6.12.

Sample output:
```
* homo_sapiens (human):
  * GRCh38: (76, 115)
  * GRCh37: (55, 75)
  * NCBI36: (54, 54)
* mus_musculus (mouse,house mouse):
  * NCBIM37: (54, 67)
  * GRCm38: (68, 102)
  * GRCm39: (103, 115)
...
```

## Test plan
- [x] `pytest tests/test_shell.py tests/test_locus.py`
- [x] `pyensembl available` smoke test
- [x] `./lint.sh`
- [x] CI on PR