### PR TITLE
Fix #219: Database cache dir defaults to download cache, not GTF directory

### DIFF
--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -321,7 +321,7 @@ class Genome(Serializable):
             self._db = Database(
                 gtf_path=self.gtf_path,
                 install_string=self.install_string(),
-                cache_directory_path=self.cache_directory_path,
+                cache_directory_path=self.download_cache.cache_directory_path,
                 restrict_gtf_columns={
                     "seqname",
                     "source",
@@ -371,7 +371,7 @@ class Genome(Serializable):
                 )
             self._protein_sequences = SequenceData(
                 fasta_paths=self.protein_fasta_paths,
-                cache_directory_path=self.cache_directory_path,
+                cache_directory_path=self.download_cache.cache_directory_path,
             )
         return self._protein_sequences
 
@@ -389,7 +389,7 @@ class Genome(Serializable):
                 )
             self._transcript_sequences = SequenceData(
                 fasta_paths=self.transcript_fasta_paths,
-                cache_directory_path=self.cache_directory_path,
+                cache_directory_path=self.download_cache.cache_directory_path,
             )
         return self._transcript_sequences
 

--- a/pyensembl/sequence_data.py
+++ b/pyensembl/sequence_data.py
@@ -11,7 +11,9 @@
 # limitations under the License.
 
 from os import remove
-from os.path import exists, abspath, split, join
+from os.path import dirname, exists, abspath, split, join
+
+import datacache
 import logging
 from collections import Counter
 import pickle
@@ -119,6 +121,7 @@ class SequenceData(object):
             fasta_dictionary_tmp = parse_fasta_dictionary(fasta_path)
             self._add_to_fasta_dictionary(fasta_dictionary_tmp)
             logger.info("Saving sequence dictionary to %s", pickle_path)
+            datacache.ensure_dir(dirname(pickle_path))
             dump_pickle(fasta_dictionary_tmp, pickle_path)
 
     def index(self, overwrite=False):

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.12"
+__version__ = "2.6.13"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_database_cache_dir.py
+++ b/tests/test_database_cache_dir.py
@@ -1,0 +1,59 @@
+"""
+Regression test for issue #219: when a Genome is constructed with a local GTF
+and no explicit cache_directory_path, the sqlite database should land in the
+download cache rather than next to the GTF file (which may be read-only).
+"""
+
+import os
+
+from pyensembl import Genome
+
+from .common import TemporaryDirectory
+
+
+GTF_BODY = (
+    '1\ttest\ttranscript\t100\t500\t.\t+\t.\t'
+    'gene_id "G1"; transcript_id "T1"; gene_name "FN1";\n'
+    '1\ttest\texon\t100\t200\t.\t+\t.\t'
+    'gene_id "G1"; transcript_id "T1"; exon_number "1"; gene_name "FN1";\n'
+    '1\ttest\texon\t300\t500\t.\t+\t.\t'
+    'gene_id "G1"; transcript_id "T1"; exon_number "2"; gene_name "FN1";\n'
+)
+
+
+def test_genome_db_cache_falls_back_to_download_cache(monkeypatch):
+    """Without an explicit cache_directory_path the Database should be
+    written under the download cache, not alongside the source GTF."""
+    with TemporaryDirectory() as cache_root, TemporaryDirectory() as gtf_dir:
+        monkeypatch.setenv("PYENSEMBL_CACHE_DIR", cache_root)
+        gtf_path = os.path.join(gtf_dir, "fix_219.gtf")
+        with open(gtf_path, "w") as f:
+            f.write(GTF_BODY)
+
+        genome = Genome(
+            reference_name="GRCh38",
+            annotation_name="fix_219_test",
+            gtf_path_or_url=gtf_path,
+        )
+
+        download_cache_dir = genome.download_cache.cache_directory_path
+        assert download_cache_dir.startswith(cache_root)
+        assert genome.db.cache_directory_path == download_cache_dir
+        assert genome.db.cache_directory_path != gtf_dir
+
+
+def test_genome_db_respects_explicit_cache_directory():
+    """An explicit cache_directory_path is still honored end-to-end."""
+    with TemporaryDirectory() as cache_dir, TemporaryDirectory() as gtf_dir:
+        gtf_path = os.path.join(gtf_dir, "fix_219_explicit.gtf")
+        with open(gtf_path, "w") as f:
+            f.write(GTF_BODY)
+
+        genome = Genome(
+            reference_name="GRCh38",
+            annotation_name="fix_219_test_explicit",
+            gtf_path_or_url=gtf_path,
+            cache_directory_path=cache_dir,
+        )
+        assert genome.db.cache_directory_path == cache_dir
+        assert genome.db.cache_directory_path != gtf_dir


### PR DESCRIPTION
## Summary
- When a `Genome` is built from a local GTF without an explicit `cache_directory_path`, the sqlite `Database` (and protein/transcript `SequenceData` caches) are now created under the resolved download-cache directory instead of next to the source GTF. Closes #219.
- The user's documented workaround (\`data._db.cache_directory_path = data.download_cache.cache_directory_path\`) is no longer necessary.
- `Database`'s standalone fallback (write next to the GTF when no `cache_directory_path` is passed) is unchanged, so callers constructing `Database` directly behave as before.
- Bumps version to 2.6.13.

## Test plan
- [x] New regression test `tests/test_database_cache_dir.py` covers both the fallback path (via `PYENSEMBL_CACHE_DIR`) and the explicit-path case
- [x] Existing `tests/test_ucsc_gtf.py` (which exercises `genome.index()` with an explicit cache dir) still passes
- [x] `./lint.sh`
- [x] CI on PR