### PR TITLE
Fix #242: expose annotation versions on Gene/Transcript/Exon/Protein

### DIFF
--- a/pyensembl/__init__.py
+++ b/pyensembl/__init__.py
@@ -28,6 +28,7 @@ from .reference_name import (
     genome_for_reference_name,
 )
 
+from .protein import Protein
 from .search import find_nearest_locus
 from .sequence_data import SequenceData
 from .species import find_species_by_name, check_species_object, normalize_species_name
@@ -43,6 +44,7 @@ __all__ = [
     "MAX_ENSEMBL_RELEASE",
     "Gene",
     "Transcript",
+    "Protein",
     "Exon",
     "SequenceData",
     "find_nearest_locus",

--- a/pyensembl/exon.py
+++ b/pyensembl/exon.py
@@ -15,11 +15,22 @@ from .locus import Locus
 
 
 class Exon(Locus):
-    def __init__(self, exon_id, contig, start, end, strand, gene_name, gene_id):
+    def __init__(
+        self,
+        exon_id,
+        contig,
+        start,
+        end,
+        strand,
+        gene_name,
+        gene_id,
+        exon_version=None,
+    ):
         Locus.__init__(self, contig, start, end, strand)
         self.exon_id = exon_id
         self.gene_name = gene_name
         self.gene_id = gene_id
+        self.exon_version = exon_version
 
     @property
     def id(self):
@@ -27,6 +38,23 @@ class Exon(Locus):
         Alias for exon_id necessary for backward compatibility.
         """
         return self.exon_id
+
+    @property
+    def version(self):
+        """Alias for :attr:`exon_version`."""
+        return self.exon_version
+
+    @property
+    def versioned_exon_id(self):
+        """``exon_id.exon_version`` when available, else ``exon_id``."""
+        if self.exon_version is None:
+            return self.exon_id
+        return "%s.%d" % (self.exon_id, self.exon_version)
+
+    @property
+    def versioned_id(self):
+        """Alias for :attr:`versioned_exon_id`."""
+        return self.versioned_exon_id
 
     def __str__(self):
         return (
@@ -69,4 +97,5 @@ class Exon(Locus):
         state_dict["exon_id"] = self.id
         state_dict["gene_name"] = self.gene_name
         state_dict["gene_id"] = self.gene_id
+        state_dict["exon_version"] = self.exon_version
         return state_dict

--- a/pyensembl/gene.py
+++ b/pyensembl/gene.py
@@ -80,6 +80,42 @@ class Gene(LocusWithGenome):
         return state_dict
 
     @memoized_property
+    def gene_version(self):
+        """
+        Ensembl annotation version for this gene (int) or None if the GTF
+        did not provide a gene_version attribute.
+        """
+        if not self.db.column_exists("gene", "gene_version"):
+            return None
+        result = self.db.query_one(
+            select_column_names=["gene_version"],
+            filter_column="gene_id",
+            filter_value=self.id,
+            feature="gene",
+            required=False,
+        )
+        if not result or not result[0]:
+            return None
+        return int(result[0])
+
+    @property
+    def version(self):
+        """Alias for :attr:`gene_version`."""
+        return self.gene_version
+
+    @property
+    def versioned_gene_id(self):
+        """``gene_id.gene_version`` when a version is available, else ``gene_id``."""
+        if self.gene_version is None:
+            return self.gene_id
+        return "%s.%d" % (self.gene_id, self.gene_version)
+
+    @property
+    def versioned_id(self):
+        """Alias for :attr:`versioned_gene_id`."""
+        return self.versioned_gene_id
+
+    @memoized_property
     def transcripts(self):
         """
         Property which dynamically construct transcript objects for all

--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -1064,14 +1064,20 @@ class Genome(Serializable):
                 "gene_name",
                 "gene_id",
             ]
+            has_exon_version = self.db.column_exists("exon", "exon_version")
+            if has_exon_version:
+                field_names.append("exon_version")
 
-            contig, start, end, strand, gene_name, gene_id = self.db.query_one(
+            row = self.db.query_one(
                 select_column_names=field_names,
                 filter_column="exon_id",
                 filter_value=exon_id,
                 feature="exon",
                 distinct=True,
             )
+            contig, start, end, strand, gene_name, gene_id = row[:6]
+            version_value = row[6] if has_exon_version else None
+            exon_version = int(version_value) if version_value else None
 
             self._exons[exon_id] = Exon(
                 exon_id=exon_id,
@@ -1081,6 +1087,7 @@ class Genome(Serializable):
                 strand=strand,
                 gene_name=gene_name,
                 gene_id=gene_id,
+                exon_version=exon_version,
             )
 
         return self._exons[exon_id]

--- a/pyensembl/protein.py
+++ b/pyensembl/protein.py
@@ -1,0 +1,71 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from serializable import Serializable
+
+
+class Protein(Serializable):
+    """
+    Lightweight view object exposing the protein identity for a transcript.
+    Accessed via :attr:`Transcript.protein`.
+    """
+
+    def __init__(self, protein_id, protein_version=None):
+        self.protein_id = protein_id
+        self.protein_version = protein_version
+
+    @property
+    def id(self):
+        """Alias for :attr:`protein_id`."""
+        return self.protein_id
+
+    @property
+    def version(self):
+        """Alias for :attr:`protein_version`."""
+        return self.protein_version
+
+    @property
+    def versioned_protein_id(self):
+        """``protein_id.protein_version`` when available, else ``protein_id``."""
+        if self.protein_version is None:
+            return self.protein_id
+        return "%s.%d" % (self.protein_id, self.protein_version)
+
+    @property
+    def versioned_id(self):
+        """Alias for :attr:`versioned_protein_id`."""
+        return self.versioned_protein_id
+
+    def __eq__(self, other):
+        return (
+            other.__class__ is Protein
+            and self.protein_id == other.protein_id
+            and self.protein_version == other.protein_version
+        )
+
+    def __hash__(self):
+        return hash((self.protein_id, self.protein_version))
+
+    def __str__(self):
+        return "Protein(protein_id='%s', protein_version=%s)" % (
+            self.protein_id,
+            self.protein_version,
+        )
+
+    def __repr__(self):
+        return str(self)
+
+    def to_dict(self):
+        return {
+            "protein_id": self.protein_id,
+            "protein_version": self.protein_version,
+        }

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -532,6 +532,42 @@ class Transcript(LocusWithGenome):
         return self.sequence[self.last_stop_codon_spliced_offset + 1 :]
 
     @memoized_property
+    def transcript_version(self):
+        """
+        Ensembl annotation version for this transcript (int) or None if the
+        GTF did not provide a transcript_version attribute.
+        """
+        if not self.db.column_exists("transcript", "transcript_version"):
+            return None
+        result = self.db.query_one(
+            select_column_names=["transcript_version"],
+            filter_column="transcript_id",
+            filter_value=self.id,
+            feature="transcript",
+            required=False,
+        )
+        if not result or not result[0]:
+            return None
+        return int(result[0])
+
+    @property
+    def version(self):
+        """Alias for :attr:`transcript_version`."""
+        return self.transcript_version
+
+    @property
+    def versioned_transcript_id(self):
+        """``transcript_id.transcript_version`` when available, else ``transcript_id``."""
+        if self.transcript_version is None:
+            return self.transcript_id
+        return "%s.%d" % (self.transcript_id, self.transcript_version)
+
+    @property
+    def versioned_id(self):
+        """Alias for :attr:`versioned_transcript_id`."""
+        return self.versioned_transcript_id
+
+    @memoized_property
     def protein_id(self):
         result_tuple = self.db.query_one(
             select_column_names=["protein_id"],
@@ -545,6 +581,32 @@ class Transcript(LocusWithGenome):
             return result_tuple[0]
         else:
             return None
+
+    @memoized_property
+    def protein(self):
+        """
+        :class:`Protein` view object for this transcript's encoded protein,
+        or ``None`` if this transcript is non-coding.
+        """
+        from .protein import Protein
+
+        if not self.protein_id:
+            return None
+        protein_version = None
+        if self.db.column_exists("CDS", "protein_version"):
+            result = self.db.query_one(
+                select_column_names=["protein_version"],
+                filter_column="transcript_id",
+                filter_value=self.id,
+                feature="CDS",
+                distinct=True,
+                required=False,
+            )
+            if result and result[0]:
+                protein_version = int(result[0])
+        return Protein(
+            protein_id=self.protein_id, protein_version=protein_version
+        )
 
     @memoized_property
     def protein_sequence(self):

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.13"
+__version__ = "2.7.0"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,111 @@
+"""
+Issue #242: expose Ensembl annotation versions on Gene, Transcript, Exon,
+and Protein (via Transcript.protein). Each entity has both a prefixed
+canonical name (``gene_version``, ``versioned_gene_id`` …) and a generic
+alias (``version``, ``versioned_id``).
+"""
+
+from pyensembl import Genome, Protein
+
+from .common import eq_, ok_
+from .data import (
+    MOUSE_ENSMUSG00000017167_PATH,
+    MOUSE_ENSMUSG00000017167_TRANSCRIPT_FASTA_PATH,
+    MOUSE_ENSMUSG00000017167_PROTEIN_FASTA_PATH,
+    data_path,
+)
+
+
+# Versions confirmed against the GTF in tests/data/ and the source
+# Ensembl 81 release: gene v6, the protein-coding transcript v3 (its protein
+# ENSMUSP00000099398 also v3) and the noncoding transcript v1. All exons v1.
+ENSEMBL_MOUSE_GTF = MOUSE_ENSMUSG00000017167_PATH
+ENSEMBL_MOUSE_TRANSCRIPT_FASTA = MOUSE_ENSMUSG00000017167_TRANSCRIPT_FASTA_PATH
+ENSEMBL_MOUSE_PROTEIN_FASTA = MOUSE_ENSMUSG00000017167_PROTEIN_FASTA_PATH
+
+TAIR10_GTF = data_path("arabidopsis.tair10.partial.gtf")
+TAIR10_CDNA_FASTA = data_path("arabidopsis.tair10.partial.cdna.fa")
+
+
+mouse_genome = Genome(
+    reference_name="GRCm38",
+    annotation_name="_test_versions_mouse_ensembl81_subset",
+    gtf_path_or_url=ENSEMBL_MOUSE_GTF,
+    transcript_fasta_paths_or_urls=[ENSEMBL_MOUSE_TRANSCRIPT_FASTA],
+    protein_fasta_paths_or_urls=[ENSEMBL_MOUSE_PROTEIN_FASTA],
+)
+
+tair_genome = Genome(
+    reference_name="TAIR10",
+    annotation_name="_test_versions_arabidopsis_tair10_subset",
+    gtf_path_or_url=TAIR10_GTF,
+    transcript_fasta_paths_or_urls=[TAIR10_CDNA_FASTA],
+)
+
+
+def setup_module(module):
+    mouse_genome.clear_cache()
+    mouse_genome.index()
+    tair_genome.clear_cache()
+    tair_genome.index()
+
+
+def test_gene_version_and_versioned_id():
+    gene = mouse_genome.gene_by_id("ENSMUSG00000017167")
+    eq_(gene.gene_version, 6)
+    eq_(gene.version, 6)
+    eq_(gene.versioned_gene_id, "ENSMUSG00000017167.6")
+    eq_(gene.versioned_id, "ENSMUSG00000017167.6")
+
+
+def test_transcript_version_and_versioned_id():
+    transcript = mouse_genome.transcript_by_id("ENSMUST00000103109")
+    eq_(transcript.transcript_version, 3)
+    eq_(transcript.version, 3)
+    eq_(transcript.versioned_transcript_id, "ENSMUST00000103109.3")
+    eq_(transcript.versioned_id, "ENSMUST00000103109.3")
+
+
+def test_transcript_protein_view():
+    transcript = mouse_genome.transcript_by_id("ENSMUST00000103109")
+    protein = transcript.protein
+    ok_(isinstance(protein, Protein))
+    eq_(protein.protein_id, "ENSMUSP00000099398")
+    eq_(protein.id, "ENSMUSP00000099398")
+    eq_(protein.protein_version, 3)
+    eq_(protein.version, 3)
+    eq_(protein.versioned_protein_id, "ENSMUSP00000099398.3")
+    eq_(protein.versioned_id, "ENSMUSP00000099398.3")
+
+
+def test_noncoding_transcript_has_no_protein():
+    transcript = mouse_genome.transcript_by_id("ENSMUST00000138942")
+    eq_(transcript.transcript_version, 1)
+    eq_(transcript.protein_id, None)
+    eq_(transcript.protein, None)
+
+
+def test_exon_version_and_versioned_id():
+    # ENSMUSE00000243064 is exon 1 of ENSMUST00000103109 at version 2
+    # (other exons in this transcript are at version 1).
+    exon = mouse_genome.exon_by_id("ENSMUSE00000243064")
+    eq_(exon.exon_version, 2)
+    eq_(exon.version, 2)
+    eq_(exon.versioned_exon_id, "ENSMUSE00000243064.2")
+    eq_(exon.versioned_id, "ENSMUSE00000243064.2")
+
+
+def test_versions_are_none_when_gtf_lacks_them():
+    # TAIR10 partial GTF has no *_version attributes; all version
+    # accessors should return None and versioned_id should equal id.
+    transcript = tair_genome.transcript_by_id("AT1G01010.1")
+    eq_(transcript.transcript_version, None)
+    eq_(transcript.version, None)
+    eq_(transcript.versioned_transcript_id, "AT1G01010.1")
+    eq_(transcript.versioned_id, "AT1G01010.1")
+
+    gene = transcript.gene
+    eq_(gene.gene_version, None)
+    eq_(gene.version, None)
+    eq_(gene.versioned_gene_id, gene.gene_id)
+    eq_(gene.versioned_id, gene.gene_id)


### PR DESCRIPTION
## Summary

Closes #242 by surfacing the Ensembl annotation version columns (already loaded into the sqlite DB) on `Gene`, `Transcript`, `Exon`, and a new `Protein` view object accessed via `Transcript.protein`.

Each type has a **prefixed canonical accessor** plus a **generic alias**:

| Entity | Canonical | Alias |
|---|---|---|
| `Gene` | `gene_version`, `versioned_gene_id` | `version`, `versioned_id` |
| `Transcript` | `transcript_version`, `versioned_transcript_id` | `version`, `versioned_id` |
| `Exon` | `exon_version`, `versioned_exon_id` | `version`, `versioned_id` |
| `Protein` (via `t.protein`) | `protein_id`, `protein_version`, `versioned_protein_id` | `id`, `version`, `versioned_id` |

Example:

```python
t = ensembl.transcript_by_id("ENSMUST00000103109")
t.transcript_version       # 3
t.versioned_transcript_id  # "ENSMUST00000103109.3"
t.version                  # 3  (alias)
t.versioned_id             # "ENSMUST00000103109.3"  (alias)
t.protein.id               # "ENSMUSP00000099398"
t.protein.versioned_id     # "ENSMUSP00000099398.3"
```

When the GTF omits version attributes (e.g. TAIR), every `*_version` returns `None` and `versioned_*` falls back to the unversioned id.

### Compatibility

- `Exon.__init__` gains a keyword-only `exon_version=None` (default preserves the old signature for positional callers).
- `Transcript.protein_id` and `Transcript.protein_sequence` stay; the new `Transcript.protein` is purely additive.
- Pyensembl's existing `.N`-stripping of FASTA IDs is unchanged — those strips are needed for sequence lookup and are orthogonal to surfacing the version on the metadata objects.
- Bumps version to **2.7.0** (additive features, no breakage).

## Test plan
- [x] `tests/test_versions.py` covers Gene/Transcript/Exon/Protein versions on mouse Ensembl 81 partial data (versions present) and on TAIR partial data (versions absent)
- [x] `pytest tests/test_versions.py tests/test_mouse.py tests/test_tair10_complete.py tests/test_serialization.py tests/test_missing_genome_sources.py tests/test_exon_object.py tests/test_locus.py tests/test_shell.py`
- [x] `./lint.sh`
- [x] CI on PR