### PR TITLE
Fix #298: route Ensembl Genomes divisions through the right server + add 9 new species

### DIFF
--- a/pyensembl/ensembl_release.py
+++ b/pyensembl/ensembl_release.py
@@ -20,7 +20,17 @@ from .genome import Genome
 from .ensembl_versions import check_release_number, MAX_ENSEMBL_RELEASE
 from .species import check_species_object, human
 
-from .ensembl_url_templates import ENSEMBL_FTP_SERVER, make_gtf_url, make_fasta_url
+from .ensembl_url_templates import (
+    ENSEMBL_FTP_SERVER,
+    ENSEMBL_GENOMES_FTP_SERVER,
+    make_gtf_url,
+    make_fasta_url,
+)
+
+
+def _default_server_for_species(species):
+    """Return the Ensembl FTP server appropriate for ``species``."""
+    return ENSEMBL_GENOMES_FTP_SERVER if species.ensembl_genomes else ENSEMBL_FTP_SERVER
 
 
 class EnsemblRelease(Genome):
@@ -37,6 +47,10 @@ class EnsemblRelease(Genome):
         """
         release = check_release_number(release)
         species = check_species_object(species)
+        if server is None or server == ENSEMBL_FTP_SERVER:
+            # Promote to the Ensembl Genomes server when the species lives
+            # there; otherwise keep the main Ensembl server.
+            server = _default_server_for_species(species)
         return (release, species, server)
 
     # Using a WeakValueDictionary instead of an ordinary dict to prevent a
@@ -74,27 +88,24 @@ class EnsemblRelease(Genome):
         self.transcript_fasta_urls = [
             make_fasta_url(
                 ensembl_release=self.release,
-                species=self.species.latin_name,
+                species=self.species,
                 sequence_type="cdna",
-                server=server,
-                is_plant = self.species.is_plant,
+                server=self.server,
             ),
             make_fasta_url(
                 ensembl_release=self.release,
-                species=self.species.latin_name,
+                species=self.species,
                 sequence_type="ncrna",
-                server=server,
-                is_plant = self.species.is_plant,
+                server=self.server,
             ),
         ]
 
         self.protein_fasta_urls = [
             make_fasta_url(
                 ensembl_release=self.release,
-                species=self.species.latin_name,
+                species=self.species,
                 sequence_type="pep",
                 server=self.server,
-                is_plant = self.species.is_plant,
             )
         ]
 

--- a/pyensembl/ensembl_url_templates.py
+++ b/pyensembl/ensembl_url_templates.py
@@ -11,32 +11,40 @@
 # limitations under the License.
 
 """
-Templates for URLs and paths to specific relase, species, and file type
-on the Ensembl ftp server.
+Templates for URLs and paths to specific release, species, and file type
+on the Ensembl ftp server (main + Ensembl Genomes).
 
 For example, the human chromosomal DNA sequences for release 78 are in:
 
     https://ftp.ensembl.org/pub/release-78/fasta/homo_sapiens/dna/
-
 """
 
 from .species import Species, find_species_by_name
 from .ensembl_versions import check_release_number
 
 ENSEMBL_FTP_SERVER = "https://ftp.ensembl.org"
-ENSEMBL_PLANTS_FTP_SERVER = "https://ftp.ensemblgenomes.ebi.ac.uk/"
+ENSEMBL_GENOMES_FTP_SERVER = "https://ftp.ensemblgenomes.ebi.ac.uk"
+# Back-compat alias; new code should use ENSEMBL_GENOMES_FTP_SERVER.
+ENSEMBL_PLANTS_FTP_SERVER = ENSEMBL_GENOMES_FTP_SERVER
 
-# Example directories
-# FASTA files: /pub/release-78/fasta/homo_sapiens/
-# GTF annotation files: /pub/release-78/gtf/homo_sapiens/
+# Path layouts:
+#   main Ensembl:    /pub/release-N/{gtf,fasta}/{species}/...
+#   Ensembl Genomes: /pub/release-N/{division}/{gtf,fasta}/{species}/...
 FASTA_SUBDIR_TEMPLATE = "/pub/release-%(release)d/fasta/%(species)s/%(type)s/"
-PLANTS_FASTA_SUBDIR_TEMPLATE = "/pub/release-%(release)d/plants/fasta/%(species)s/%(type)s/"
 GTF_SUBDIR_TEMPLATE = "/pub/release-%(release)d/gtf/%(species)s/"
-PLANTS_GTF_SUBDIR_TEMPLATE = "/pub/release-%(release)d/plants/gtf/%(species)s/"
+GENOMES_FASTA_SUBDIR_TEMPLATE = (
+    "/pub/release-%(release)d/%(division)s/fasta/%(species)s/%(type)s/"
+)
+GENOMES_GTF_SUBDIR_TEMPLATE = (
+    "/pub/release-%(release)d/%(division)s/gtf/%(species)s/"
+)
 
-#List plants
-#Lest do a vector with all the plants species that we added to make the custom url
-lPlants = ("arabidopsis_thaliana","arabidopsis")
+
+def _resolve_species(species):
+    if isinstance(species, Species):
+        return species
+    return find_species_by_name(species)
+
 
 def normalize_release_properties(ensembl_release, species):
     """
@@ -44,44 +52,55 @@ def normalize_release_properties(ensembl_release, species):
     normalize the species name, and get its associated reference.
     """
     ensembl_release = check_release_number(ensembl_release)
-    if not isinstance(species, Species):
-        species = find_species_by_name(species)
+    species = _resolve_species(species)
     reference_name = species.which_reference(ensembl_release)
     return ensembl_release, species.latin_name, reference_name
 
 
-# GTF annotation file example: Homo_sapiens.GTCh38.gtf.gz
+# GTF annotation file example: Homo_sapiens.GRCh38.gtf.gz
 GTF_FILENAME_TEMPLATE = "%(Species)s.%(reference)s.%(release)d.gtf.gz"
 
 
 def make_gtf_filename(ensembl_release, species):
     """
-    Return GTF filename expect on Ensembl FTP server for a specific
-    species/release combination
+    Return GTF filename expected on the Ensembl FTP server for a specific
+    species/release combination.
     """
-    ensembl_release, species, reference_name = normalize_release_properties(
+    ensembl_release, species_name, reference_name = normalize_release_properties(
         ensembl_release, species
     )
     return GTF_FILENAME_TEMPLATE % {
-        "Species": species.capitalize(),
+        "Species": species_name.capitalize(),
         "reference": reference_name,
         "release": ensembl_release,
     }
 
 
-def make_gtf_url(ensembl_release, species, server=ENSEMBL_FTP_SERVER, gtf_subdir=GTF_SUBDIR_TEMPLATE):
+def make_gtf_url(ensembl_release, species, server=None):
     """
-    Returns a URL and a filename, which can be joined together.
+    Returns a fully-qualified URL to the GTF file for ``species`` at
+    ``ensembl_release``. Routes through the Ensembl Genomes server when
+    ``species.ensembl_genomes`` is True, else through main Ensembl.
     """
-    if species.is_plant:
-        server = ENSEMBL_PLANTS_FTP_SERVER
-        gtf_subdir = PLANTS_GTF_SUBDIR_TEMPLATE
-    #else:
-        #print(f"[+] {species.latin_name} it is not a plant", flush=True)
-
-    ensembl_release, species, _ = normalize_release_properties(ensembl_release, species)
-    subdir = gtf_subdir % {"release": ensembl_release, "species": species}
-    filename = make_gtf_filename(ensembl_release=ensembl_release, species=species)
+    species = _resolve_species(species)
+    if species.ensembl_genomes:
+        if server is None:
+            server = ENSEMBL_GENOMES_FTP_SERVER
+        subdir = GENOMES_GTF_SUBDIR_TEMPLATE % {
+            "release": check_release_number(ensembl_release),
+            "division": species.division,
+            "species": species.latin_name,
+        }
+    else:
+        if server is None:
+            server = ENSEMBL_FTP_SERVER
+        subdir = GTF_SUBDIR_TEMPLATE % {
+            "release": check_release_number(ensembl_release),
+            "species": species.latin_name,
+        }
+    filename = make_gtf_filename(
+        ensembl_release=ensembl_release, species=species
+    )
     return server + subdir + filename
 
 
@@ -90,75 +109,88 @@ def make_gtf_url(ensembl_release, species, server=ENSEMBL_FTP_SERVER, gtf_subdir
 OLD_FASTA_FILENAME_TEMPLATE = (
     "%(Species)s.%(reference)s.%(release)d.%(sequence_type)s.all.fa.gz"
 )
-
-# ncRNA FASTA file for releases before (and including) Ensembl 75
-# example: Homo_sapiens.NCBI36.54.ncrna.fa.gz
-
-OLD_FASTA_FILENAME_TEMPLATE_NCRNA = "%(Species)s.%(reference)s.%(release)d.ncrna.fa.gz"
-
-# cDNA & protein FASTA file for releases after Ensembl 75
-# example: Homo_sapiens.GRCh37.cdna.all.fa.gz
-NEW_FASTA_FILENAME_TEMPLATE = "%(Species)s.%(reference)s.%(sequence_type)s.all.fa.gz"
-
-# ncRNA FASTA file for releases after Ensembl 75
-# example: Homo_sapiens.GRCh37.ncrna.fa.gz
+OLD_FASTA_FILENAME_TEMPLATE_NCRNA = (
+    "%(Species)s.%(reference)s.%(release)d.ncrna.fa.gz"
+)
+# cDNA & protein FASTA for releases after Ensembl 75 (and all Ensembl Genomes
+# releases, which use the modern layout regardless of release number).
+NEW_FASTA_FILENAME_TEMPLATE = (
+    "%(Species)s.%(reference)s.%(sequence_type)s.all.fa.gz"
+)
 NEW_FASTA_FILENAME_TEMPLATE_NCRNA = "%(Species)s.%(reference)s.ncrna.fa.gz"
 
 
-def make_fasta_filename(ensembl_release, species, sequence_type, is_plant):
-    ensembl_release, species, reference_name = normalize_release_properties(
+def make_fasta_filename(ensembl_release, species, sequence_type, is_plant=None):
+    """
+    ``is_plant`` is accepted for backward compatibility but ignored; the
+    layout is now derived from ``species.ensembl_genomes``.
+    """
+    species = _resolve_species(species)
+    ensembl_release, species_name, reference_name = normalize_release_properties(
         ensembl_release, species
     )
-    if ensembl_release <= 75 and not is_plant:
-        if sequence_type == "ncrna":
-            return OLD_FASTA_FILENAME_TEMPLATE_NCRNA % {
-                "Species": species.capitalize(),
-                "reference": reference_name,
-                "release": ensembl_release,
-            }
-        else:
-            return OLD_FASTA_FILENAME_TEMPLATE % {
-                "Species": species.capitalize(),
-                "reference": reference_name,
-                "release": ensembl_release,
-                "sequence_type": sequence_type,
-            }
-    else:
+    use_new_layout = ensembl_release > 75 or species.ensembl_genomes
+    if use_new_layout:
         if sequence_type == "ncrna":
             return NEW_FASTA_FILENAME_TEMPLATE_NCRNA % {
-                "Species": species.capitalize(),
+                "Species": species_name.capitalize(),
                 "reference": reference_name,
             }
-        else:
-            return NEW_FASTA_FILENAME_TEMPLATE % {
-                "Species": species.capitalize(),
-                "reference": reference_name,
-                "sequence_type": sequence_type,
-            }
+        return NEW_FASTA_FILENAME_TEMPLATE % {
+            "Species": species_name.capitalize(),
+            "reference": reference_name,
+            "sequence_type": sequence_type,
+        }
+    if sequence_type == "ncrna":
+        return OLD_FASTA_FILENAME_TEMPLATE_NCRNA % {
+            "Species": species_name.capitalize(),
+            "reference": reference_name,
+            "release": ensembl_release,
+        }
+    return OLD_FASTA_FILENAME_TEMPLATE % {
+        "Species": species_name.capitalize(),
+        "reference": reference_name,
+        "release": ensembl_release,
+        "sequence_type": sequence_type,
+    }
 
 
-def make_fasta_url(ensembl_release, species, sequence_type, is_plant, server=ENSEMBL_FTP_SERVER, fasta_subdir=FASTA_SUBDIR_TEMPLATE):
-    """Construct URL to FASTA file with cDNA transcript or protein sequences
+def make_fasta_url(
+    ensembl_release,
+    species,
+    sequence_type,
+    is_plant=None,
+    server=None,
+):
+    """Construct URL to FASTA file with cDNA transcript or protein sequences.
 
-    Parameter examples:
-        ensembl_release = 75
-        species = "Homo_sapiens"
-        sequence_type = "cdna" (other option: "pep")
+    ``is_plant`` is accepted for backward compatibility but ignored; routing
+    is derived from ``species.ensembl_genomes`` and ``species.division``.
     """
-    ensembl_release, species, reference_name = normalize_release_properties(
+    species = _resolve_species(species)
+    ensembl_release, species_name, _ = normalize_release_properties(
         ensembl_release, species
     )
-
-    if is_plant:
-        server = ENSEMBL_PLANTS_FTP_SERVER
-        fasta_subdir = PLANTS_FASTA_SUBDIR_TEMPLATE
-
-    subdir = fasta_subdir % {
-        "release": ensembl_release,
-        "species": species,
-        "type": sequence_type,
-    }
+    if species.ensembl_genomes:
+        if server is None:
+            server = ENSEMBL_GENOMES_FTP_SERVER
+        subdir = GENOMES_FASTA_SUBDIR_TEMPLATE % {
+            "release": ensembl_release,
+            "division": species.division,
+            "species": species_name,
+            "type": sequence_type,
+        }
+    else:
+        if server is None:
+            server = ENSEMBL_FTP_SERVER
+        subdir = FASTA_SUBDIR_TEMPLATE % {
+            "release": ensembl_release,
+            "species": species_name,
+            "type": sequence_type,
+        }
     filename = make_fasta_filename(
-        ensembl_release=ensembl_release, species=species, sequence_type=sequence_type, is_plant = is_plant
+        ensembl_release=ensembl_release,
+        species=species,
+        sequence_type=sequence_type,
     )
     return server + subdir + filename

--- a/pyensembl/ensembl_versions.py
+++ b/pyensembl/ensembl_versions.py
@@ -12,7 +12,11 @@
 
 MIN_ENSEMBL_RELEASE = 40
 MAX_ENSEMBL_RELEASE = 115
-MAX_PLANTS_ENSEMBL_RELEASE = 58
+# Ensembl Genomes (plants, fungi, metazoa, protists, bacteria) has its own
+# release numbering that runs separately from the main Ensembl release. The
+# `MAX_PLANTS_ENSEMBL_RELEASE` alias is preserved for backward compatibility.
+MAX_ENSEMBL_GENOMES_RELEASE = 58
+MAX_PLANTS_ENSEMBL_RELEASE = MAX_ENSEMBL_GENOMES_RELEASE
 
 
 def check_release_number(release):

--- a/pyensembl/species.py
+++ b/pyensembl/species.py
@@ -12,7 +12,10 @@
 
 from serializable import Serializable
 
-from .ensembl_versions import MAX_ENSEMBL_RELEASE, MAX_PLANTS_ENSEMBL_RELEASE
+from .ensembl_versions import (
+    MAX_ENSEMBL_RELEASE,
+    MAX_ENSEMBL_GENOMES_RELEASE,
+)
 
 # TODO: replace Serializable with data class
 
@@ -36,22 +39,26 @@ class Species(Serializable):
         synonyms,
         reference_assemblies,
         division="vertebrates",
+        ensembl_genomes=False,
         is_plant=False,
     ):
         """
         Create a Species object from the given arguments and enter into
         all the dicts used to look the species up by its fields.
 
-        ``is_plant`` is retained for backward compatibility; new callers
-        should pass ``division`` instead.
+        ``is_plant`` is retained for backward compatibility and implies
+        ``division="plants"`` and ``ensembl_genomes=True``. New callers
+        should pass ``division`` and ``ensembl_genomes`` directly.
         """
         if is_plant:
             division = "plants"
+            ensembl_genomes = True
         species = Species(
             latin_name=latin_name,
             synonyms=synonyms,
             reference_assemblies=reference_assemblies,
             division=division,
+            ensembl_genomes=ensembl_genomes,
         )
         cls._latin_names_to_species[species.latin_name] = species
         for synonym in synonyms:
@@ -103,6 +110,7 @@ class Species(Serializable):
         synonyms=[],
         reference_assemblies={},
         division="vertebrates",
+        ensembl_genomes=False,
     ):
         """
         Parameters
@@ -119,6 +127,14 @@ class Species(Serializable):
             Ensembl division this species belongs to. One of
             ``"vertebrates"``, ``"plants"``, ``"fungi"``, ``"metazoa"``,
             ``"protists"``, ``"bacteria"``. Defaults to ``"vertebrates"``.
+
+        ensembl_genomes : bool
+            If True, the species' annotation and FASTA files live on the
+            Ensembl Genomes server (``ftp.ensemblgenomes.ebi.ac.uk``) under
+            the ``/{division}/...`` subtree, with their own release
+            numbering (1..MAX_ENSEMBL_GENOMES_RELEASE). If False (default)
+            the species is served from the main Ensembl FTP at
+            ``ftp.ensembl.org``.
         """
         if division not in self.VALID_DIVISIONS:
             raise ValueError(
@@ -129,6 +145,7 @@ class Species(Serializable):
         self.synonyms = synonyms
         self.reference_assemblies = reference_assemblies
         self.division = division
+        self.ensembl_genomes = ensembl_genomes
         self._release_to_genome = {}
         for genome_name, (start, end) in self.reference_assemblies.items():
             for i in range(start, end + 1):
@@ -421,18 +438,114 @@ arabidopsis_thaliana = Species.register(
     latin_name="arabidopsis_thaliana",
     synonyms=["arabidopsis"],
     reference_assemblies={
-        "TAIR10": (40, MAX_PLANTS_ENSEMBL_RELEASE),
+        "TAIR10": (40, MAX_ENSEMBL_GENOMES_RELEASE),
     },
     division="plants",
+    ensembl_genomes=True,
 )
 
 rice = Species.register(
     latin_name="oryza_sativa",
     synonyms=["rice"],
     reference_assemblies={
-        "IRGSP-1.0": (40, MAX_PLANTS_ENSEMBL_RELEASE),
+        "IRGSP-1.0": (40, MAX_ENSEMBL_GENOMES_RELEASE),
     },
     division="plants",
+    ensembl_genomes=True,
+)
+
+# Additional Ensembl Genomes species (issue #298).
+# Release ranges use the conservative lower bound 40 to match the existing
+# plants entries; older releases at this assembly version may 404.
+
+wheat = Species.register(
+    latin_name="triticum_aestivum",
+    synonyms=["wheat", "bread_wheat"],
+    reference_assemblies={
+        "IWGSC": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+    },
+    division="plants",
+    ensembl_genomes=True,
+)
+
+maize = Species.register(
+    latin_name="zea_mays",
+    synonyms=["maize", "corn"],
+    reference_assemblies={
+        "Zm-B73-REFERENCE-NAM-5.0": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+    },
+    division="plants",
+    ensembl_genomes=True,
+)
+
+tomato = Species.register(
+    latin_name="solanum_lycopersicum",
+    synonyms=["tomato"],
+    reference_assemblies={
+        "SL3.0": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+    },
+    division="plants",
+    ensembl_genomes=True,
+)
+
+fission_yeast = Species.register(
+    latin_name="schizosaccharomyces_pombe",
+    synonyms=["fission_yeast", "pombe"],
+    reference_assemblies={
+        "ASM294v2": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+    },
+    division="fungi",
+    ensembl_genomes=True,
+)
+
+aspergillus_nidulans = Species.register(
+    latin_name="aspergillus_nidulans",
+    synonyms=["aspergillus"],
+    reference_assemblies={
+        "ASM1142v1": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+    },
+    division="fungi",
+    ensembl_genomes=True,
+)
+
+candida_albicans = Species.register(
+    latin_name="candida_albicans",
+    synonyms=["candida"],
+    reference_assemblies={
+        "GCA000182965v3": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+    },
+    division="fungi",
+    ensembl_genomes=True,
+)
+
+anopheles_gambiae = Species.register(
+    latin_name="anopheles_gambiae",
+    synonyms=["mosquito", "malaria_mosquito"],
+    reference_assemblies={
+        "AgamP4": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+    },
+    division="metazoa",
+    ensembl_genomes=True,
+)
+
+plasmodium_falciparum = Species.register(
+    latin_name="plasmodium_falciparum",
+    synonyms=["plasmodium", "malaria_parasite"],
+    reference_assemblies={
+        "ASM276v2": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+    },
+    division="protists",
+    ensembl_genomes=True,
+)
+
+toxoplasma_gondii = Species.register(
+    latin_name="toxoplasma_gondii",
+    synonyms=["toxoplasma"],
+    reference_assemblies={
+        "TGA4": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+    },
+    division="protists",
+    ensembl_genomes=True,
 )
 
 #BALB/c

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.8.0"
+__version__ = "2.9.0"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_ensembl_genomes_species.py
+++ b/tests/test_ensembl_genomes_species.py
@@ -1,0 +1,108 @@
+"""
+Tests for #298: more species support across Ensembl Genomes divisions
+(plants / fungi / metazoa / protists) and the URL-template branch that
+routes them through ``ftp.ensemblgenomes.ebi.ac.uk``.
+"""
+
+from pyensembl import EnsemblRelease
+from pyensembl.ensembl_url_templates import (
+    ENSEMBL_FTP_SERVER,
+    ENSEMBL_GENOMES_FTP_SERVER,
+)
+from pyensembl.ensembl_versions import MAX_ENSEMBL_GENOMES_RELEASE
+from pyensembl.species import (
+    Species,
+    anopheles_gambiae,
+    arabidopsis_thaliana,
+    aspergillus_nidulans,
+    candida_albicans,
+    fission_yeast,
+    maize,
+    plasmodium_falciparum,
+    rice,
+    tomato,
+    toxoplasma_gondii,
+    wheat,
+)
+
+
+GENOMES_SPECIES_BY_DIVISION = {
+    "plants": [arabidopsis_thaliana, rice, wheat, maize, tomato],
+    "fungi": [fission_yeast, aspergillus_nidulans, candida_albicans],
+    "metazoa": [anopheles_gambiae],
+    "protists": [plasmodium_falciparum, toxoplasma_gondii],
+}
+
+
+def test_ensembl_genomes_species_have_expected_divisions():
+    for division, species_list in GENOMES_SPECIES_BY_DIVISION.items():
+        for species in species_list:
+            assert species.division == division, (
+                "%s should be tagged division=%s, got %s"
+                % (species.latin_name, division, species.division)
+            )
+            assert species.ensembl_genomes is True
+
+
+def test_ensembl_genomes_species_route_through_genomes_server():
+    for species_list in GENOMES_SPECIES_BY_DIVISION.values():
+        for species in species_list:
+            release = EnsemblRelease(
+                release=MAX_ENSEMBL_GENOMES_RELEASE, species=species
+            )
+            assert release.server == ENSEMBL_GENOMES_FTP_SERVER
+            assert release.gtf_url.startswith(ENSEMBL_GENOMES_FTP_SERVER)
+            assert "/%s/gtf/%s/" % (species.division, species.latin_name) in (
+                release.gtf_url
+            )
+            for url in release.transcript_fasta_urls + release.protein_fasta_urls:
+                assert url.startswith(ENSEMBL_GENOMES_FTP_SERVER)
+                assert "/%s/fasta/%s/" % (species.division, species.latin_name) in url
+
+
+def test_genomes_filenames_use_modern_layout_regardless_of_release():
+    # Older Ensembl releases (<= 75) used a different filename pattern on
+    # main Ensembl. Ensembl Genomes uses the modern pattern at every release.
+    release = EnsemblRelease(release=40, species=wheat)
+    for url in release.transcript_fasta_urls + release.protein_fasta_urls:
+        assert ".40." not in url, (
+            "Ensembl Genomes FASTA filenames should not embed the release"
+            " number, got %s" % url
+        )
+
+
+def test_existing_non_vertebrate_species_stay_on_main_ensembl():
+    """yeast / drosophila / C. elegans are tagged taxonomically as
+    fungi/metazoa but their reference_assemblies are registered against main
+    Ensembl release numbers, so they must keep routing through ftp.ensembl.org.
+    """
+    for latin_name in (
+        "saccharomyces_cerevisiae",
+        "drosophila_melanogaster",
+        "caenorhabditis_elegans",
+    ):
+        species = Species._latin_names_to_species[latin_name]
+        assert species.ensembl_genomes is False
+        release = EnsemblRelease(release=110, species=species)
+        assert release.server == ENSEMBL_FTP_SERVER
+        assert release.gtf_url.startswith(ENSEMBL_FTP_SERVER)
+
+
+def test_is_plant_kwarg_back_compat_implies_ensembl_genomes():
+    species = Species.register(
+        latin_name="_test_legacy_is_plant_species",
+        synonyms=["_test_legacy"],
+        reference_assemblies={"FakeAsm": (40, MAX_ENSEMBL_GENOMES_RELEASE)},
+        is_plant=True,
+    )
+    try:
+        assert species.is_plant is True
+        assert species.division == "plants"
+        assert species.ensembl_genomes is True
+    finally:
+        # Remove the test fixture so it doesn't leak into other tests.
+        Species._latin_names_to_species.pop(species.latin_name, None)
+        for synonym in species.synonyms:
+            Species._common_names_to_species.pop(synonym, None)
+        for ref in species.reference_assemblies:
+            Species._reference_names_to_species.pop(ref, None)


### PR DESCRIPTION
## Summary

Finishes the work begun in #342 by actually wiring up Ensembl Genomes routing and adding new species. Closes #298.

### Infrastructure changes
- `Species` gains an `ensembl_genomes` boolean. When True, GTF + FASTA URLs are built against `ftp.ensemblgenomes.ebi.ac.uk` under `/pub/release-N/{division}/...`.
- New `MAX_ENSEMBL_GENOMES_RELEASE = 58` constant for the parallel Ensembl Genomes release stream. `MAX_PLANTS_ENSEMBL_RELEASE` is preserved as an alias.
- URL builders (`make_gtf_url`, `make_fasta_url`, `make_fasta_filename`) now branch on `species.ensembl_genomes` and `species.division` instead of the old `is_plant` boolean. `is_plant=True` on `Species.register` is preserved as a shorthand for `division="plants"` + `ensembl_genomes=True`.
- `EnsemblRelease` auto-upgrades the default server when the species lives on Ensembl Genomes, so omitting `server=` does the right thing.
- Filename templates use the modern layout (no embedded release number) for any Ensembl Genomes species at any release; the older numbered layout is reserved for main Ensembl releases <= 75.

### New species (9, across all 4 non-vertebrate Ensembl Genomes divisions)

| Division | Latin name | Common name | Assembly |
|---|---|---|---|
| plants | `triticum_aestivum` | wheat | `IWGSC` |
| plants | `zea_mays` | maize | `Zm-B73-REFERENCE-NAM-5.0` |
| plants | `solanum_lycopersicum` | tomato | `SL3.0` |
| fungi | `schizosaccharomyces_pombe` | fission_yeast / pombe | `ASM294v2` |
| fungi | `aspergillus_nidulans` | aspergillus | `ASM1142v1` |
| fungi | `candida_albicans` | candida | `GCA000182965v3` |
| metazoa | `anopheles_gambiae` | mosquito | `AgamP4` |
| protists | `plasmodium_falciparum` | plasmodium | `ASM276v2` |
| protists | `toxoplasma_gondii` | toxoplasma | `TGA4` |

All 44 generated URLs (GTF + cDNA + ncRNA + protein FASTA × 11 Ensembl Genomes species) were verified to return HTTP 200 from `ftp.ensemblgenomes.ebi.ac.uk` at release 58.

### Backward compatibility
- `is_plant=True` still works on `Species.register` — it routes the species to plants + Ensembl Genomes.
- Existing `EnsemblRelease(server=ENSEMBL_FTP_SERVER)` callers are auto-upgraded to the Genomes server only when the species needs it; explicit non-default servers are honored.
- Yeast / drosophila / C. elegans stay on main Ensembl (`ensembl_genomes=False`) — their pre-existing release ranges (`76-115`) only have files on main Ensembl. They're taxonomically `fungi` / `metazoa` but their files live on main Ensembl; the `ensembl_genomes` flag captures that.

Bumps version to **2.9.0**.

## Test plan
- [x] New `tests/test_ensembl_genomes_species.py` (5 tests): division tagging, Genomes-server routing, modern filename layout regardless of release, yeast/fly/C.elegans still on main Ensembl, `is_plant=True` back-compat.
- [x] Full local test sweep: 157 passed (excluding the network-bound `test_ensembl_gtf.py`).
- [x] Manual verification: HEAD-checked all 44 new URLs against the Ensembl Genomes FTP server (all 200).
- [x] `./lint.sh`
- [x] CI on PR.