### PR TITLE
Fix #283: add Genome.nearest_gene / nearest_transcript

### DIFF
--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -25,6 +25,7 @@ from .download_cache import DownloadCache
 from .database import Database
 from .exon import Exon
 from .gene import Gene
+from .search import find_nearest_locus
 from .sequence_data import SequenceData
 from .transcript import Transcript
 
@@ -566,6 +567,40 @@ class Genome(Serializable):
     def exons_at_locus(self, contig, position, end=None, strand=None):
         exon_ids = self.exon_ids_at_locus(contig, position, end=end, strand=strand)
         return [self.exon_by_id(exon_id) for exon_id in exon_ids]
+
+    def nearest_gene(self, contig, position, end=None, strand=None):
+        """
+        Find the gene on ``contig`` whose locus is nearest to the position
+        (or position..end interval), even if no gene actually overlaps.
+
+        Returns ``(distance, Gene)`` where ``distance`` is the number of
+        intervening bases (0 if the query interval falls inside the gene).
+        Returns ``(inf, None)`` when the contig has no genes on the
+        requested strand.
+
+        Pass ``strand`` to restrict the search to one strand of the contig.
+        """
+        if end is None:
+            end = position
+        return find_nearest_locus(
+            start=position,
+            end=end,
+            loci=self.genes(contig=contig, strand=strand),
+        )
+
+    def nearest_transcript(self, contig, position, end=None, strand=None):
+        """
+        Find the transcript on ``contig`` whose locus is nearest to the
+        position (or position..end interval), even if no transcript
+        overlaps. See :meth:`nearest_gene` for the return shape.
+        """
+        if end is None:
+            end = position
+        return find_nearest_locus(
+            start=position,
+            end=end,
+            loci=self.transcripts(contig=contig, strand=strand),
+        )
 
     def gene_ids_at_locus(self, contig, position, end=None, strand=None):
         return self.db.distinct_column_values_at_locus(

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.1"
+__version__ = "2.9.2"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_nearest_feature.py
+++ b/tests/test_nearest_feature.py
@@ -1,0 +1,90 @@
+"""
+Issue #283: surface find_nearest_locus as Genome.nearest_gene /
+Genome.nearest_transcript so callers can locate the closest annotated
+feature to a position even when no feature overlaps it directly.
+"""
+
+from pyensembl import Gene, Transcript
+
+from .common import eq_
+from .data import (
+    custom_mouse_genome_grcm38_subset,
+    setup_init_custom_mouse_genome,
+)
+
+
+def setup_module(module):
+    setup_init_custom_mouse_genome()
+
+
+def test_nearest_gene_overlapping_returns_distance_zero():
+    # ENSMUSG00000017167 spans chr11:101170523-101190724 on +; query
+    # inside the gene must return distance 0 and that gene.
+    distance, gene = custom_mouse_genome_grcm38_subset.nearest_gene(
+        contig="11", position=101180000
+    )
+    eq_(distance, 0)
+    assert isinstance(gene, Gene)
+    eq_(gene.id, "ENSMUSG00000017167")
+
+
+def test_nearest_gene_upstream_position_reports_gap():
+    # 1000 bases upstream of gene start (101170523)
+    distance, gene = custom_mouse_genome_grcm38_subset.nearest_gene(
+        contig="11", position=101169523
+    )
+    eq_(distance, 1000)
+    eq_(gene.id, "ENSMUSG00000017167")
+
+
+def test_nearest_gene_downstream_interval_reports_gap():
+    # interval entirely downstream of gene end (101190724); distance
+    # is gap from end of interval to start of next feature backward,
+    # i.e. position 101200724 - gene.end 101190724 = 10000.
+    distance, gene = custom_mouse_genome_grcm38_subset.nearest_gene(
+        contig="11", position=101200724, end=101201000
+    )
+    eq_(distance, 10000)
+    eq_(gene.id, "ENSMUSG00000017167")
+
+
+def test_nearest_gene_on_empty_contig_returns_none():
+    distance, gene = custom_mouse_genome_grcm38_subset.nearest_gene(
+        contig="22", position=100
+    )
+    eq_(distance, float("inf"))
+    eq_(gene, None)
+
+
+def test_nearest_transcript_overlapping_returns_distance_zero():
+    distance, transcript = (
+        custom_mouse_genome_grcm38_subset.nearest_transcript(
+            contig="11", position=101180000
+        )
+    )
+    eq_(distance, 0)
+    assert isinstance(transcript, Transcript)
+    # both transcripts overlap; either is acceptable, just confirm we got one
+    assert transcript.id in {"ENSMUST00000103109", "ENSMUST00000138942"}
+
+
+def test_nearest_transcript_upstream_picks_closer_endpoint():
+    # ENSMUST00000138942 starts at 101170523, ENSMUST00000103109 at 101176041;
+    # query at 101170000 is 523 bp from the closer transcript.
+    distance, transcript = (
+        custom_mouse_genome_grcm38_subset.nearest_transcript(
+            contig="11", position=101170000
+        )
+    )
+    eq_(distance, 523)
+    eq_(transcript.id, "ENSMUST00000138942")
+
+
+def test_nearest_gene_strand_filter():
+    # Restricting to the wrong strand (the only gene is on +) should
+    # produce no candidates.
+    distance, gene = custom_mouse_genome_grcm38_subset.nearest_gene(
+        contig="11", position=101180000, strand="-"
+    )
+    eq_(distance, float("inf"))
+    eq_(gene, None)


### PR DESCRIPTION
## Summary
Surfaces the existing `find_nearest_locus` helper as `Genome.nearest_gene(contig, position, end=None, strand=None)` and `Genome.nearest_transcript(...)` so callers can locate the closest annotated feature to a position even when no feature overlaps it directly.

Returns `(distance, Gene)` / `(distance, Transcript)`. `distance` is 0 when the query interval falls inside the feature, otherwise the number of bases of gap. Returns `(inf, None)` when there are no candidates on the contig / requested strand.

Closes #283.

## Test plan
- [x] `tests/test_nearest_feature.py` covers: overlapping query → 0, upstream/downstream gaps, empty-contig fallback to `(inf, None)`, transcript-picker chooses the closer-endpoint transcript, strand filter
- [x] `pytest tests/test_nearest_feature.py tests/test_biotype_filter.py tests/test_mouse.py tests/test_versions.py` (19 passed locally)
- [x] `./lint.sh`
- [x] CI on PR

Bumps version to **2.9.2**.