### PR TITLE
Fix #186: Locus.intersect returns overlap region or None

### DIFF
--- a/pyensembl/locus.py
+++ b/pyensembl/locus.py
@@ -240,6 +240,25 @@ class Locus(Serializable):
             return 0
         return max(0, min(self.end, other.end) - max(self.start, other.start) + 1)
 
+    def intersect(self, other, ignore_strand=False):
+        """
+        Return a new :class:`Locus` covering the inclusive-inclusive
+        overlap between this locus and ``other``, or ``None`` if they do
+        not overlap. Mirrors bedtools' ``intersect`` for a single pair.
+
+        Different contigs always return ``None``. Different strands return
+        ``None`` unless ``ignore_strand=True`` is passed, in which case the
+        result is reported on this locus's strand.
+        """
+        strand = None if ignore_strand else other.strand
+        if not self.can_overlap(other.contig, strand):
+            return None
+        start = max(self.start, other.start)
+        end = min(self.end, other.end)
+        if start > end:
+            return None
+        return Locus(contig=self.contig, start=start, end=end, strand=self.strand)
+
     def contains(self, contig, start, end, strand=None):
         return (
             self.can_overlap(contig, strand) and start >= self.start and end <= self.end

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.2"
+__version__ = "2.9.3"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_locus.py
+++ b/tests/test_locus.py
@@ -189,3 +189,24 @@ def test_locus_overlap_length():
     other_neg = Locus("1", 10, 20, "-")
     assert locus.overlap_length(other_neg) == 0
     assert locus.overlap_length(other_neg, ignore_strand=True) == 11
+
+
+def test_locus_intersect():
+    a = Locus("1", 10, 20, "+")
+    # full overlap (other contained in a)
+    eq_result = a.intersect(Locus("1", 12, 15, "+"))
+    assert eq_result == Locus("1", 12, 15, "+")
+    # partial overlap (right tail of a)
+    assert a.intersect(Locus("1", 15, 30, "+")) == Locus("1", 15, 20, "+")
+    # partial overlap (left tail of a)
+    assert a.intersect(Locus("1", 1, 15, "+")) == Locus("1", 10, 15, "+")
+    # single-base boundary overlap
+    assert a.intersect(Locus("1", 20, 30, "+")) == Locus("1", 20, 20, "+")
+    # adjacent, non-overlapping
+    assert a.intersect(Locus("1", 21, 30, "+")) is None
+    # different contig
+    assert a.intersect(Locus("2", 10, 20, "+")) is None
+    # opposite strand: None by default, accepts when ignore_strand=True
+    other_neg = Locus("1", 12, 18, "-")
+    assert a.intersect(other_neg) is None
+    assert a.intersect(other_neg, ignore_strand=True) == Locus("1", 12, 18, "+")


### PR DESCRIPTION
## Summary
Adds `Locus.intersect(other, ignore_strand=False)` returning a new `Locus` covering the inclusive-inclusive overlap between two loci, or `None` when they don't overlap. Mirrors bedtools' single-pair intersect. The result is reported on `self`'s strand. Closes #186.

Combines with the existing `overlap_length` (#260) helper:

```python
exon = transcript.exons[0]
chunk = Locus("1", 1_000_000, 1_000_050, "+")
overlap = exon.intersect(chunk)  # Locus or None
```

## Test plan
- [x] `tests/test_locus.py` covers: full overlap, partial overlaps (both tails), single-base boundary overlap, adjacent-non-overlapping, different contig, opposite strand (with and without `ignore_strand`)
- [x] `pytest tests/test_locus.py tests/test_versions.py`
- [x] `./lint.sh`
- [x] CI on PR

Bumps version to **2.9.3**.