### PR TITLE
Add Xenopus + soybean species, tighten maize/tomato ranges (follow-up to #334)

### DIFF
--- a/pyensembl/species.py
+++ b/pyensembl/species.py
@@ -397,6 +397,15 @@ zebrafish = Species.register(
     },
 )
 
+xenopus = Species.register(
+    latin_name="xenopus_tropicalis",
+    synonyms=["xenopus", "western_clawed_frog", "tropical_clawed_frog"],
+    reference_assemblies={
+        "Xenopus_tropicalis_v9.1": (98, 106),
+        "UCB_Xtro_10.0": (107, MAX_ENSEMBL_RELEASE),
+    },
+)
+
 fly = Species.register(
     latin_name="drosophila_melanogaster",
     synonyms=["drosophila", "fruit fly", "fly"],
@@ -472,7 +481,10 @@ maize = Species.register(
     latin_name="zea_mays",
     synonyms=["maize", "corn"],
     reference_assemblies={
-        "Zm-B73-REFERENCE-NAM-5.0": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+        # Zm-B73-REFERENCE-NAM-5.0 was introduced at Ensembl Plants release
+        # 54; earlier releases used a different assembly and returned 404
+        # for this asset.
+        "Zm-B73-REFERENCE-NAM-5.0": (54, MAX_ENSEMBL_GENOMES_RELEASE),
     },
     division="plants",
     ensembl_genomes=True,
@@ -482,7 +494,17 @@ tomato = Species.register(
     latin_name="solanum_lycopersicum",
     synonyms=["tomato"],
     reference_assemblies={
-        "SL3.0": (40, MAX_ENSEMBL_GENOMES_RELEASE),
+        "SL3.0": (42, MAX_ENSEMBL_GENOMES_RELEASE),
+    },
+    division="plants",
+    ensembl_genomes=True,
+)
+
+soybean = Species.register(
+    latin_name="glycine_max",
+    synonyms=["soybean", "soya_bean"],
+    reference_assemblies={
+        "Glycine_max_v2.1": (43, MAX_ENSEMBL_GENOMES_RELEASE),
     },
     division="plants",
     ensembl_genomes=True,

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.4"
+__version__ = "2.9.5"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_ensembl_genomes_species.py
+++ b/tests/test_ensembl_genomes_species.py
@@ -20,6 +20,7 @@ from pyensembl.species import (
     maize,
     plasmodium_falciparum,
     rice,
+    soybean,
     tomato,
     toxoplasma_gondii,
     wheat,
@@ -27,7 +28,7 @@ from pyensembl.species import (
 
 
 GENOMES_SPECIES_BY_DIVISION = {
-    "plants": [arabidopsis_thaliana, rice, wheat, maize, tomato],
+    "plants": [arabidopsis_thaliana, rice, wheat, maize, tomato, soybean],
     "fungi": [fission_yeast, aspergillus_nidulans, candida_albicans],
     "metazoa": [anopheles_gambiae],
     "protists": [plasmodium_falciparum, toxoplasma_gondii],
@@ -86,6 +87,26 @@ def test_existing_non_vertebrate_species_stay_on_main_ensembl():
         release = EnsemblRelease(release=110, species=species)
         assert release.server == ENSEMBL_FTP_SERVER
         assert release.gtf_url.startswith(ENSEMBL_FTP_SERVER)
+
+
+def test_xenopus_picks_assembly_by_release():
+    """Xenopus tropicalis is served from main Ensembl with two assemblies:
+    Xenopus_tropicalis_v9.1 covers releases 98-106 and UCB_Xtro_10.0
+    covers 107 onwards. Verify both halves route through main Ensembl
+    and resolve to the right assembly per release."""
+    from pyensembl.ensembl_url_templates import ENSEMBL_FTP_SERVER
+
+    xenopus = Species._latin_names_to_species["xenopus_tropicalis"]
+    assert xenopus.division == "vertebrates"
+    assert xenopus.ensembl_genomes is False
+
+    r106 = EnsemblRelease(release=106, species=xenopus)
+    assert r106.server == ENSEMBL_FTP_SERVER
+    assert "Xenopus_tropicalis_v9.1" in r106.gtf_url
+
+    r107 = EnsemblRelease(release=107, species=xenopus)
+    assert r107.server == ENSEMBL_FTP_SERVER
+    assert "UCB_Xtro_10.0" in r107.gtf_url
 
 
 def test_is_plant_kwarg_back_compat_implies_ensembl_genomes():


### PR DESCRIPTION
## Summary
Follow-up to #334, which has been open since 2026-05-05. After today's #298 work (PR #343, v2.9.0) added maize and tomato directly, #334 as-written would collide on import; this PR picks up the additive parts and corrects the inaccurate ranges.

### Changes

| Change | Why |
|---|---|
| Tighten maize from `(40, MAX_ENSEMBL_GENOMES_RELEASE)` to `(54, …)` | `Zm-B73-REFERENCE-NAM-5.0` doesn't exist on the Plants FTP until release 54; v2.9.0's range was too generous |
| Tighten tomato from `(40, …)` to `(42, …)` | Same reason — `SL3.0` first at release 42 |
| Add `glycine_max` (soybean) — `division="plants"`, `ensembl_genomes=True`, `(43, MAX_ENSEMBL_GENOMES_RELEASE)` | New species (was in #334) |
| Add `xenopus_tropicalis` to main Ensembl with two assemblies — `Xenopus_tropicalis_v9.1: (98, 106)` and `UCB_Xtro_10.0: (107, MAX_ENSEMBL_RELEASE)` | New species. #334 proposed `(100, …)` for UCB_Xtro_10.0 alone; verified against the FTP, UCB_Xtro_10.0 doesn't appear until release 107, with v9.1 covering 98–106 |
| Add `soybean` to `tests/test_ensembl_genomes_species.py` plants list, plus a new test verifying the Xenopus assembly switchover at release 106→107 | Test coverage |

### URL verification

All seven generated GTF URLs HEAD-checked against the live FTP:

```
zea_mays                r54   200
solanum_lycopersicum    r42   200
glycine_max             r43   200
xenopus_tropicalis      r98   200  (v9.1)
xenopus_tropicalis      r106  200  (v9.1)
xenopus_tropicalis      r107  200  (UCB_Xtro_10.0)
xenopus_tropicalis      r115  200  (UCB_Xtro_10.0)
```

Bumps version to **2.9.5**.

## Test plan
- [x] `pytest tests/test_ensembl_genomes_species.py tests/test_shell.py tests/test_versions.py tests/test_locus.py tests/test_release_versions.py tests/test_merged_gene_intervals.py tests/test_nearest_feature.py tests/test_biotype_filter.py` (47 passed locally)
- [x] `./lint.sh`
- [x] Manual: HEAD-checked all 7 URLs against the Ensembl FTP server
- [x] CI on PR