### PR TITLE
Fix #335 (part 2): tolerate versioned IDs in protein/transcript FASTA lookups

### DIFF
--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -28,7 +28,7 @@ from .exon import Exon
 from .gene import Gene
 from .normalization import normalize_chromosome, normalize_strand
 from .search import find_nearest_locus
-from .sequence_data import SequenceData
+from .sequence_data import SequenceData, sequence_lookup_with_ens_fallback
 from .transcript import Transcript
 
 
@@ -540,19 +540,25 @@ class Genome(Serializable):
 
     def transcript_sequence(self, transcript_id):
         """Return cDNA nucleotide sequence of transcript, or None if
-        transcript doesn't have cDNA sequence.
+        transcript doesn't have cDNA sequence. Accepts both versioned
+        (``ENST00000123456.7``) and unversioned identifiers.
         """
         if self.transcript_sequences is None:
             raise ValueError("No transcript FASTA supplied to this Genome: %s" % self)
-        return self.transcript_sequences.get(transcript_id)
+        return sequence_lookup_with_ens_fallback(
+            self.transcript_sequences, transcript_id
+        )
 
     def protein_sequence(self, protein_id):
-        """Return cDNA nucleotide sequence of transcript, or None if
-        transcript doesn't have cDNA sequence.
+        """Return amino-acid sequence of protein, or None if the protein is
+        absent from the FASTA. Accepts both versioned
+        (``ENSP00000123456.3``) and unversioned identifiers.
         """
         if self.protein_sequences is None:
             raise ValueError("No protein FASTA supplied to this Genome: %s" % self)
-        return self.protein_sequences.get(protein_id)
+        return sequence_lookup_with_ens_fallback(
+            self.protein_sequences, protein_id
+        )
 
     def genes_at_locus(self, contig, position, end=None, strand=None):
         gene_ids = self.gene_ids_at_locus(contig, position, end=end, strand=strand)

--- a/pyensembl/sequence_data.py
+++ b/pyensembl/sequence_data.py
@@ -24,6 +24,28 @@ from .fasta import parse_fasta_dictionary
 logger = logging.getLogger(__name__)
 
 
+def sequence_lookup_with_ens_fallback(sequence_data, identifier):
+    """
+    Look up ``identifier`` in ``sequence_data``. If the lookup misses and the
+    identifier looks like an Ensembl ID with a version suffix (e.g.
+    ``"ENSP00000123456.3"``), strip the suffix and try again.
+
+    Needed because pyensembl's FASTA parser strips ENS.N suffixes from
+    headers (so the dictionary key is the unversioned ID) but GENCODE GTFs
+    embed the version in ``protein_id`` / ``transcript_id`` attributes, so
+    a literal lookup would miss.
+    """
+    if not identifier:
+        return None
+    sequence = sequence_data.get(identifier)
+    if sequence is not None:
+        return sequence
+    if identifier.startswith("ENS") and "." in identifier:
+        stripped = identifier.rsplit(".", 1)[0]
+        return sequence_data.get(stripped)
+    return None
+
+
 class SequenceData(object):
     """
     Container for reference nucleotide and amino acid sequenes.

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -15,6 +15,7 @@ from memoized_property import memoized_property
 from .common import memoize, merge_intervals
 from .exon import Exon
 from .locus_with_genome import LocusWithGenome
+from .sequence_data import sequence_lookup_with_ens_fallback
 
 
 # Back-compat alias for callers that imported the private helper.
@@ -443,10 +444,9 @@ class Transcript(LocusWithGenome):
         Spliced cDNA sequence of transcript
         (includes 5" UTR, coding sequence, and 3" UTR)
         """
-        transcript_id = self.transcript_id
-        if transcript_id.startswith("ENS"):
-            transcript_id = transcript_id.rsplit(".", 1)[0]
-        return self.genome.transcript_sequences.get(transcript_id)
+        return sequence_lookup_with_ens_fallback(
+            self.genome.transcript_sequences, self.transcript_id
+        )
 
     @memoized_property
     def first_start_codon_spliced_offset(self):
@@ -596,7 +596,8 @@ class Transcript(LocusWithGenome):
 
     @memoized_property
     def protein_sequence(self):
-        if self.protein_id:
-            return self.genome.protein_sequences.get(self.protein_id)
-        else:
+        if not self.protein_id:
             return None
+        return sequence_lookup_with_ens_fallback(
+            self.genome.protein_sequences, self.protein_id
+        )

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.5"
+__version__ = "2.9.6"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_versioned_protein_fasta.py
+++ b/tests/test_versioned_protein_fasta.py
@@ -1,0 +1,118 @@
+"""
+Issue #335 (part 2): tolerate versioned protein / transcript IDs in FASTA
+lookups for GENCODE-style genomes.
+
+GENCODE embeds the assembly version directly in the ``protein_id`` and
+``transcript_id`` GTF attributes (e.g. ``protein_id "ENSP00000123456.3"``),
+while pyensembl's FASTA parser strips ``.N`` suffixes from ENS-prefix
+headers. Before this fix the literal lookup with the versioned ID missed,
+so ``Transcript.protein_sequence`` and ``Genome.transcript_sequence``
+returned ``None`` for GENCODE FASTAs even when the sequence was present.
+"""
+
+import os
+
+from pyensembl import Genome
+
+from .common import TemporaryDirectory, eq_
+
+
+GENCODE_STYLE_GTF = """\
+1\ttest\ttranscript\t100\t800\t.\t+\t.\tgene_id "ENSGTEST00000000001.4"; transcript_id "ENSTTEST00000000001.5"; gene_name "FAKE1"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
+1\ttest\texon\t100\t800\t.\t+\t.\tgene_id "ENSGTEST00000000001.4"; transcript_id "ENSTTEST00000000001.5"; exon_number "1"; exon_id "ENSETEST00000000001.2"; gene_name "FAKE1"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
+1\ttest\tCDS\t100\t798\t.\t+\t0\tgene_id "ENSGTEST00000000001.4"; transcript_id "ENSTTEST00000000001.5"; exon_number "1"; exon_id "ENSETEST00000000001.2"; protein_id "ENSPTEST00000000001.3"; gene_name "FAKE1"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
+1\ttest\tstart_codon\t100\t102\t.\t+\t0\tgene_id "ENSGTEST00000000001.4"; transcript_id "ENSTTEST00000000001.5"; gene_name "FAKE1"; protein_id "ENSPTEST00000000001.3"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
+1\ttest\tstop_codon\t799\t801\t.\t+\t0\tgene_id "ENSGTEST00000000001.4"; transcript_id "ENSTTEST00000000001.5"; gene_name "FAKE1"; protein_id "ENSPTEST00000000001.3"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
+"""
+
+# GENCODE-style FASTA: pipe-delimited header carrying the versioned ID.
+PROTEIN_FASTA = (
+    ">ENSPTEST00000000001.3|ENSTTEST00000000001.5|ENSGTEST00000000001.4|"
+    "OTTHUMG00000000001.1|OTTHUMT00000000001.1|FAKE1-001|FAKE1|266\n"
+    "MFAKEPROTEINSEQUENCE\n"
+)
+TRANSCRIPT_FASTA = (
+    ">ENSTTEST00000000001.5|ENSGTEST00000000001.4|OTTHUMG00000000001.1|"
+    "OTTHUMT00000000001.1|FAKE1-001|FAKE1|800|protein_coding|\n"
+    "ATGCCCAAATTTGGGCCCAAATTT\n"
+)
+
+
+def _make_genome(tmpdir, with_transcript=True, with_protein=True):
+    gtf_path = os.path.join(tmpdir, "gencode_style.gtf")
+    with open(gtf_path, "w") as f:
+        f.write(GENCODE_STYLE_GTF)
+    transcript_fasta = None
+    protein_fasta = None
+    if with_transcript:
+        transcript_fasta = os.path.join(tmpdir, "gencode_style.cdna.fa")
+        with open(transcript_fasta, "w") as f:
+            f.write(TRANSCRIPT_FASTA)
+    if with_protein:
+        protein_fasta = os.path.join(tmpdir, "gencode_style.pep.fa")
+        with open(protein_fasta, "w") as f:
+            f.write(PROTEIN_FASTA)
+    return Genome(
+        reference_name="GRCh38",
+        annotation_name="_test_gencode_versioned_335",
+        gtf_path_or_url=gtf_path,
+        transcript_fasta_paths_or_urls=[transcript_fasta] if transcript_fasta else [],
+        protein_fasta_paths_or_urls=[protein_fasta] if protein_fasta else [],
+        cache_directory_path=tmpdir,
+    )
+
+
+def test_transcript_protein_sequence_with_gencode_versioned_id():
+    """The CDS row stores ``protein_id "ENSPTEST00000000001.3"`` (with the
+    GENCODE version suffix); the FASTA parser strips the suffix so the
+    dict key is ``ENSPTEST00000000001``. ``Transcript.protein_sequence``
+    must recover the sequence by stripping the version before lookup."""
+    with TemporaryDirectory() as tmpdir:
+        genome = _make_genome(tmpdir)
+        genome.index()
+        transcript = genome.transcript_by_id("ENSTTEST00000000001.5")
+        # protein_id is preserved verbatim from the GTF (with version)
+        eq_(transcript.protein_id, "ENSPTEST00000000001.3")
+        # but the sequence is still recovered
+        eq_(transcript.protein_sequence, "MFAKEPROTEINSEQUENCE")
+
+
+def test_transcript_sequence_with_gencode_versioned_id():
+    with TemporaryDirectory() as tmpdir:
+        genome = _make_genome(tmpdir)
+        genome.index()
+        transcript = genome.transcript_by_id("ENSTTEST00000000001.5")
+        eq_(transcript.sequence, "ATGCCCAAATTTGGGCCCAAATTT")
+
+
+def test_genome_protein_sequence_accepts_versioned_id():
+    """Genome.protein_sequence("ENSP....N") should resolve even when the
+    FASTA dict keys are unversioned."""
+    with TemporaryDirectory() as tmpdir:
+        genome = _make_genome(tmpdir, with_transcript=False)
+        genome.index()
+        eq_(
+            genome.protein_sequence("ENSPTEST00000000001.3"),
+            "MFAKEPROTEINSEQUENCE",
+        )
+        # unversioned form still works (existing behavior)
+        eq_(
+            genome.protein_sequence("ENSPTEST00000000001"),
+            "MFAKEPROTEINSEQUENCE",
+        )
+        # bogus id returns None, not a KeyError or stripped-form hit
+        eq_(genome.protein_sequence("ENSPNOTAREAL00000000.1"), None)
+
+
+def test_genome_transcript_sequence_accepts_versioned_id():
+    with TemporaryDirectory() as tmpdir:
+        genome = _make_genome(tmpdir, with_protein=False)
+        genome.index()
+        eq_(
+            genome.transcript_sequence("ENSTTEST00000000001.5"),
+            "ATGCCCAAATTTGGGCCCAAATTT",
+        )
+        eq_(
+            genome.transcript_sequence("ENSTTEST00000000001"),
+            "ATGCCCAAATTTGGGCCCAAATTT",
+        )


### PR DESCRIPTION
## Summary

GENCODE GTFs embed the version directly in `protein_id` / `transcript_id` (e.g. `protein_id "ENSP00000123456.3"`). pyensembl's FASTA parser strips `.N` suffixes from ENS-prefix headers so the dict key is unversioned. Before this fix the literal lookup with the versioned ID missed and `Transcript.protein_sequence` returned `None` for GENCODE FASTAs even when the sequence was present — one of the two root causes called out in #335.

### Fix

Centralizes a small helper in `pyensembl/sequence_data.py`:

```python
def sequence_lookup_with_ens_fallback(sequence_data, identifier):
    """Try `identifier` as-is; on miss strip ENS.N suffix and try again."""
```

Wires it into the four FASTA lookup sites:

| Caller | Before | After |
|---|---|---|
| `Transcript.sequence` | always strips, then `.get()` | tries versioned, then strips |
| `Transcript.protein_sequence` | `.get(self.protein_id)` (no stripping → 404 for GENCODE) | tries versioned, then strips |
| `Genome.transcript_sequence(id)` | `.get(id)` (no stripping) | tries id, then strips |
| `Genome.protein_sequence(id)` | `.get(id)` (no stripping) | tries id, then strips |

`Transcript.sequence` already worked for GENCODE (it stripped). This PR makes its behavior consistent with the other three accessors.

### Test plan
- [x] New `tests/test_versioned_protein_fasta.py` builds a synthetic GENCODE-style fixture (versioned `protein_id` in GTF, pipe-delimited versioned header in FASTA) and verifies all four accessors recover the sequence
- [x] `pytest tests/test_versioned_protein_fasta.py tests/test_mouse.py tests/test_tair10_complete.py tests/test_versions.py tests/test_sequence_data.py tests/test_transcript_sequences.py` (20 passed locally)
- [x] `./lint.sh`
- [x] CI on PR

### Out of scope

This fixes the protein/transcript-ID half of #335. The biotype-naming half (`gene_type` / `transcript_type` vs `gene_biotype` / `transcript_biotype`) is a separate small PR (#335 part 1).

Bumps version to **2.9.6**.