### PR TITLE
Rename FASTA lookup helper: sequence_lookup_with_ens_fallback → lookup_sequence_with_version_fallback

### DIFF
--- a/pyensembl/genome.py
+++ b/pyensembl/genome.py
@@ -28,7 +28,7 @@ from .exon import Exon
 from .gene import Gene
 from .normalization import normalize_chromosome, normalize_strand
 from .search import find_nearest_locus
-from .sequence_data import SequenceData, sequence_lookup_with_ens_fallback
+from .sequence_data import SequenceData, lookup_sequence_with_version_fallback
 from .transcript import Transcript
 
 
@@ -545,7 +545,7 @@ class Genome(Serializable):
         """
         if self.transcript_sequences is None:
             raise ValueError("No transcript FASTA supplied to this Genome: %s" % self)
-        return sequence_lookup_with_ens_fallback(
+        return lookup_sequence_with_version_fallback(
             self.transcript_sequences, transcript_id
         )
 
@@ -556,7 +556,7 @@ class Genome(Serializable):
         """
         if self.protein_sequences is None:
             raise ValueError("No protein FASTA supplied to this Genome: %s" % self)
-        return sequence_lookup_with_ens_fallback(
+        return lookup_sequence_with_version_fallback(
             self.protein_sequences, protein_id
         )
 

--- a/pyensembl/sequence_data.py
+++ b/pyensembl/sequence_data.py
@@ -24,16 +24,25 @@ from .fasta import parse_fasta_dictionary
 logger = logging.getLogger(__name__)
 
 
-def sequence_lookup_with_ens_fallback(sequence_data, identifier):
+def lookup_sequence_with_version_fallback(sequence_data, identifier):
     """
-    Look up ``identifier`` in ``sequence_data``. If the lookup misses and the
-    identifier looks like an Ensembl ID with a version suffix (e.g.
-    ``"ENSP00000123456.3"``), strip the suffix and try again.
+    Look up ``identifier`` in ``sequence_data``, tolerating an ENS.N version
+    suffix mismatch between the caller's ID and the FASTA's dict keys.
 
-    Needed because pyensembl's FASTA parser strips ENS.N suffixes from
-    headers (so the dictionary key is the unversioned ID) but GENCODE GTFs
-    embed the version in ``protein_id`` / ``transcript_id`` attributes, so
-    a literal lookup would miss.
+    Both Ensembl and GENCODE work with versioned IDs (e.g.
+    ``ENSP00000123456.3``); the two formats just split that information
+    differently. Ensembl GTFs keep the bare ID in ``protein_id`` /
+    ``transcript_id`` and put the version in a separate ``*_version``
+    attribute, while GENCODE GTFs embed the version directly in the ID
+    attribute. pyensembl's FASTA parser strips ``.N`` from ENS-prefix
+    headers, so the FASTA dict keys are always unversioned — meaning a
+    literal lookup of a GENCODE-style versioned ID would miss.
+
+    Strategy: try ``identifier`` as-is first (covers both unversioned IDs
+    and any future FASTA that preserves versions); on miss, strip a
+    trailing ``.N`` suffix and try again, but only for ENS-prefix IDs
+    because for non-Ensembl IDs (e.g. TAIR ``AT1G01010.1``) the ``.N`` is
+    an isoform suffix and stripping would be incorrect.
     """
     if not identifier:
         return None

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -15,7 +15,7 @@ from memoized_property import memoized_property
 from .common import memoize, merge_intervals
 from .exon import Exon
 from .locus_with_genome import LocusWithGenome
-from .sequence_data import sequence_lookup_with_ens_fallback
+from .sequence_data import lookup_sequence_with_version_fallback
 
 
 # Back-compat alias for callers that imported the private helper.
@@ -444,7 +444,7 @@ class Transcript(LocusWithGenome):
         Spliced cDNA sequence of transcript
         (includes 5" UTR, coding sequence, and 3" UTR)
         """
-        return sequence_lookup_with_ens_fallback(
+        return lookup_sequence_with_version_fallback(
             self.genome.transcript_sequences, self.transcript_id
         )
 
@@ -598,6 +598,6 @@ class Transcript(LocusWithGenome):
     def protein_sequence(self):
         if not self.protein_id:
             return None
-        return sequence_lookup_with_ens_fallback(
+        return lookup_sequence_with_version_fallback(
             self.genome.protein_sequences, self.protein_id
         )

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.6"
+__version__ = "2.9.7"
 
 def print_version():
     print(f"v{__version__}")


### PR DESCRIPTION
## Summary

The helper I added in #350 / v2.9.6 was misnamed. ENS isn't the *fallback* — both Ensembl and GENCODE protein/transcript IDs start with ENS. The actual fallback is to a **version-stripped** form of the same ID; the ENS-prefix check is just a guard that says "this ID has a version we know how to strip safely" (in contrast to e.g. TAIR `AT1G01010.1` where `.1` is an isoform suffix, not a version).

Renamed to `lookup_sequence_with_version_fallback` and the docstring is rewritten to correctly describe both Ensembl and GENCODE as having versioned IDs (they just split that information differently across the GTF / FASTA pair).

Internal helper only — not exported from `pyensembl/__init__.py`, was added today in v2.9.6, so no external callers can depend on the old name. **No back-compat shim.**

Three call sites updated:
- `Transcript.sequence`
- `Transcript.protein_sequence`
- `Genome.transcript_sequence(id)` / `Genome.protein_sequence(id)`

Bumps version to **2.9.7**.

## Test plan
- [x] `pytest tests/test_versioned_protein_fasta.py tests/test_mouse.py tests/test_tair10_complete.py tests/test_versions.py tests/test_sequence_data.py tests/test_transcript_sequences.py` (20 passed locally)
- [x] `./lint.sh`
- [x] CI on PR