### PR TITLE
docs: drop README line-number anchors that drift on every source change

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,66 +166,67 @@ combinations of the annotation features _gene_name_, _gene_id_,
 _transcript_name_, _transcript_id_, _exon_id_ as well as the location of
 these genomic elements (contig, start position, end position, strand).
 
-Method names link to their source in `pyensembl/genome.py`; class names
+Method names link to the source file in `pyensembl/genome.py`; class names
 ([Gene][gene-class], [Transcript][transcript-class], [Exon][exon-class])
-link to the corresponding class definitions.
+link to the corresponding class files. Use the file's symbol outline or
+search the page for the method name to jump to the definition.
 
 ## Genes
 
 <dl>
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L742">genes(contig=None, strand=None, biotype=None)</a></dt>
-<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#L19">Gene</a> objects, optionally restricted to a particular contig,
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">genes(contig=None, strand=None, biotype=None)</a></dt>
+<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a> objects, optionally restricted to a particular contig,
 strand, or <code>gene_biotype</code>.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L557">genes_at_locus(contig, position, end=None, strand=None)</a></dt>
-<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#L19">Gene</a> objects overlapping a particular position on a contig,
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">genes_at_locus(contig, position, end=None, strand=None)</a></dt>
+<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a> objects overlapping a particular position on a contig,
 optionally extend into a range with the end parameter and restrict to
 forward or backward strand by passing strand='+' or strand='-'.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L762">gene_by_id(gene_id)</a></dt>
-<dd>Return a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#L19">Gene</a> object for given Ensembl gene ID (e.g. "ENSG00000068793").</dd>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_by_id(gene_id)</a></dt>
+<dd>Return a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a> object for given Ensembl gene ID (e.g. "ENSG00000068793").</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L854">gene_names(contig=None, strand=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_names(contig=None, strand=None)</a></dt>
 <dd>Returns all gene names in the annotation database, optionally restricted
 to a particular contig or strand.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L820">genes_by_name(gene_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">genes_by_name(gene_name)</a></dt>
 <dd>Get all the unique genes with the given name (there might be multiple
-due to copies in the genome), return a list containing a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#L19">Gene</a> object for each
+due to copies in the genome), return a list containing a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a> object for each
 distinct ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L829">gene_by_protein_id(protein_id)</a></dt>
-<dd>Find <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#L19">Gene</a> associated with the given Ensembl protein ID (e.g. "ENSP00000350283")</dd>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_by_protein_id(protein_id)</a></dt>
+<dd>Find <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a> associated with the given Ensembl protein ID (e.g. "ENSP00000350283")</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L635">gene_names_at_locus(contig, position, end=None, strand=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_names_at_locus(contig, position, end=None, strand=None)</a></dt>
 <dd>Names of genes overlapping with the given locus, optionally restricted by strand.
 (returns a list to account for overlapping genes)</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L863">gene_name_of_gene_id(gene_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_name_of_gene_id(gene_id)</a></dt>
 <dd>Returns name of gene with given gene ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L866">gene_name_of_transcript_id(transcript_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_name_of_transcript_id(transcript_id)</a></dt>
 <dd>Returns name of gene associated with given transcript ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L869">gene_name_of_transcript_name(transcript_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_name_of_transcript_name(transcript_name)</a></dt>
 <dd>Returns name of gene associated with given transcript name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L872">gene_name_of_exon_id(exon_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_name_of_exon_id(exon_id)</a></dt>
 <dd>Returns name of gene associated with given exon ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L892">gene_ids(contig=None, strand=None, biotype=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_ids(contig=None, strand=None, biotype=None)</a></dt>
 <dd>Return all gene IDs in the annotation database, optionally restricted by
 chromosome name, strand, or <code>gene_biotype</code>.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L905">gene_ids_of_gene_name(gene_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_ids_of_gene_name(gene_name)</a></dt>
 <dd>Returns all Ensembl gene IDs with the given name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L573">nearest_gene(contig, position, end=None, strand=None)</a></dt>
-<dd>Returns <code>(distance, <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#L19">Gene</a>)</code> for the gene whose locus is nearest to the
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">nearest_gene(contig, position, end=None, strand=None)</a></dt>
+<dd>Returns <code>(distance, <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a>)</code> for the gene whose locus is nearest to the
 position (or position..end interval) on the given contig — even when no
 gene overlaps. Returns <code>(inf, None)</code> when no candidates exist.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L593">merged_gene_intervals(contig, strand=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">merged_gene_intervals(contig, strand=None)</a></dt>
 <dd>Returns the union of all gene loci on the contig as a sorted list of
 non-overlapping <code>(start, end)</code> tuples. Adjacent intervals
 (<code>end+1 == next start</code>) are merged into one.</dd>
@@ -235,63 +236,63 @@ non-overlapping <code>(start, end)</code> tuples. Adjacent intervals
 ## Transcripts
 
 <dl>
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L938">transcripts(contig=None, strand=None, biotype=None)</a></dt>
-<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py#L24">Transcript</a> objects for all transcript entries in the
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcripts(contig=None, strand=None, biotype=None)</a></dt>
+<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py">Transcript</a> objects for all transcript entries in the
 Ensembl database, optionally restricted to a particular contig, strand, or
 <code>transcript_biotype</code>.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L951">transcript_by_id(transcript_id)</a></dt>
-<dd>Construct a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py#L24">Transcript</a> object for given Ensembl transcript ID (e.g. "ENST00000369985")</dd>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_by_id(transcript_id)</a></dt>
+<dd>Construct a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py">Transcript</a> object for given Ensembl transcript ID (e.g. "ENST00000369985")</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1014">transcripts_by_name(transcript_name)</a></dt>
-<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py#L24">Transcript</a> objects for every transcript matching the given name.</dd>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcripts_by_name(transcript_name)</a></dt>
+<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py">Transcript</a> objects for every transcript matching the given name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1041">transcript_names(contig=None, strand=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_names(contig=None, strand=None)</a></dt>
 <dd>Returns all transcript names in the annotation database.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1082">transcript_ids(contig=None, strand=None, biotype=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_ids(contig=None, strand=None, biotype=None)</a></dt>
 <dd>Returns all transcript IDs in the annotation database.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1091">transcript_ids_of_gene_id(gene_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_ids_of_gene_id(gene_id)</a></dt>
 <dd>Return IDs of all transcripts associated with given gene ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1094">transcript_ids_of_gene_name(gene_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_ids_of_gene_name(gene_name)</a></dt>
 <dd>Return IDs of all transcripts associated with given gene name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1097">transcript_ids_of_transcript_name(transcript_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_ids_of_transcript_name(transcript_name)</a></dt>
 <dd>Find all Ensembl transcript IDs with the given name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1100">transcript_ids_of_exon_id(exon_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_ids_of_exon_id(exon_id)</a></dt>
 <dd>Return IDs of all transcripts associated with given exon ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L611">nearest_transcript(contig, position, end=None, strand=None)</a></dt>
-<dd>Returns <code>(distance, <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py#L24">Transcript</a>)</code> to the closest transcript on the contig.
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">nearest_transcript(contig, position, end=None, strand=None)</a></dt>
+<dd>Returns <code>(distance, <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py">Transcript</a>)</code> to the closest transcript on the contig.
 Returns <code>(inf, None)</code> when no candidates exist.</dd>
 </dl>
 
 ## Exons
 
 <dl>
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1193">exon_ids(contig=None, strand=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_ids(contig=None, strand=None)</a></dt>
 <dd>Returns a list of exon IDs in the annotation database, optionally restricted
 by the given chromosome and strand.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1135">exon_by_id(exon_id)</a></dt>
-<dd>Construct an <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/exon.py#L17">Exon</a> object for given Ensembl exon ID (e.g. "ENSE00001209410")</dd>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_by_id(exon_id)</a></dt>
+<dd>Construct an <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/exon.py">Exon</a> object for given Ensembl exon ID (e.g. "ENSE00001209410")</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1198">exon_ids_of_gene_id(gene_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_ids_of_gene_id(gene_id)</a></dt>
 <dd>Returns a list of exon IDs associated with a given gene ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1201">exon_ids_of_gene_name(gene_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_ids_of_gene_name(gene_name)</a></dt>
 <dd>Returns a list of exon IDs associated with a given gene name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1207">exon_ids_of_transcript_id(transcript_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_ids_of_transcript_id(transcript_id)</a></dt>
 <dd>Returns a list of exon IDs associated with a given transcript ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#L1204">exon_ids_of_transcript_name(transcript_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_ids_of_transcript_name(transcript_name)</a></dt>
 <dd>Returns a list of exon IDs associated with a given transcript name.</dd>
 </dl>
 
-[gene-class]: https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#L19
-[transcript-class]: https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py#L24
-[exon-class]: https://github.com/openvax/pyensembl/blob/main/pyensembl/exon.py#L17
+[gene-class]: https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py
+[transcript-class]: https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py
+[exon-class]: https://github.com/openvax/pyensembl/blob/main/pyensembl/exon.py


### PR DESCRIPTION
## Summary

The line-number anchors I added to the README API tables in #348 (e.g. `genome.py#L573`) were already off by 6 lines after #350 (v2.9.6) — that PR grew `Genome.protein_sequence`'s docstring by a few lines and shifted every method below it. The transcript class anchor was off by 1 from earlier additions in v2.7.0. Re-pinning them after every release isn't sustainable.

This PR strips `#Lnnn` from every `<file>.py` link in the README. The clickable target is still the method name and lands on the right file; readers can use the browser's outline / symbol search / ctrl-F to jump to the definition.

## Diff at a glance
- 45 source links updated
- 1 intro sentence rephrased to drop the "line anchor" promise and explain the alternative
- No code changes, no version bump

## Test plan
- [x] `grep -c "#L" README.md` = 0 (was 45)
- [x] All 45 source links still resolve to a file on `main`