### PR TITLE
docs: use text-fragment anchors in README so methods land precisely

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,67 +166,62 @@ combinations of the annotation features _gene_name_, _gene_id_,
 _transcript_name_, _transcript_id_, _exon_id_ as well as the location of
 these genomic elements (contig, start position, end position, strand).
 
-Method names link to the source file in `pyensembl/genome.py`; class names
-([Gene][gene-class], [Transcript][transcript-class], [Exon][exon-class])
-link to the corresponding class files. Use the file's symbol outline or
-search the page for the method name to jump to the definition.
-
 ## Genes
 
 <dl>
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">genes(contig=None, strand=None, biotype=None)</a></dt>
-<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a> objects, optionally restricted to a particular contig,
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20genes(">genes(contig=None, strand=None, biotype=None)</a></dt>
+<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#:~:text=class%20Gene(">Gene</a> objects, optionally restricted to a particular contig,
 strand, or <code>gene_biotype</code>.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">genes_at_locus(contig, position, end=None, strand=None)</a></dt>
-<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a> objects overlapping a particular position on a contig,
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20genes_at_locus(">genes_at_locus(contig, position, end=None, strand=None)</a></dt>
+<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#:~:text=class%20Gene(">Gene</a> objects overlapping a particular position on a contig,
 optionally extend into a range with the end parameter and restrict to
 forward or backward strand by passing strand='+' or strand='-'.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_by_id(gene_id)</a></dt>
-<dd>Return a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a> object for given Ensembl gene ID (e.g. "ENSG00000068793").</dd>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20gene_by_id(">gene_by_id(gene_id)</a></dt>
+<dd>Return a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#:~:text=class%20Gene(">Gene</a> object for given Ensembl gene ID (e.g. "ENSG00000068793").</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_names(contig=None, strand=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20gene_names(">gene_names(contig=None, strand=None)</a></dt>
 <dd>Returns all gene names in the annotation database, optionally restricted
 to a particular contig or strand.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">genes_by_name(gene_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20genes_by_name(">genes_by_name(gene_name)</a></dt>
 <dd>Get all the unique genes with the given name (there might be multiple
-due to copies in the genome), return a list containing a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a> object for each
+due to copies in the genome), return a list containing a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#:~:text=class%20Gene(">Gene</a> object for each
 distinct ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_by_protein_id(protein_id)</a></dt>
-<dd>Find <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a> associated with the given Ensembl protein ID (e.g. "ENSP00000350283")</dd>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20gene_by_protein_id(">gene_by_protein_id(protein_id)</a></dt>
+<dd>Find <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#:~:text=class%20Gene(">Gene</a> associated with the given Ensembl protein ID (e.g. "ENSP00000350283")</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_names_at_locus(contig, position, end=None, strand=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20gene_names_at_locus(">gene_names_at_locus(contig, position, end=None, strand=None)</a></dt>
 <dd>Names of genes overlapping with the given locus, optionally restricted by strand.
 (returns a list to account for overlapping genes)</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_name_of_gene_id(gene_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20gene_name_of_gene_id(">gene_name_of_gene_id(gene_id)</a></dt>
 <dd>Returns name of gene with given gene ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_name_of_transcript_id(transcript_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20gene_name_of_transcript_id(">gene_name_of_transcript_id(transcript_id)</a></dt>
 <dd>Returns name of gene associated with given transcript ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_name_of_transcript_name(transcript_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20gene_name_of_transcript_name(">gene_name_of_transcript_name(transcript_name)</a></dt>
 <dd>Returns name of gene associated with given transcript name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_name_of_exon_id(exon_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20gene_name_of_exon_id(">gene_name_of_exon_id(exon_id)</a></dt>
 <dd>Returns name of gene associated with given exon ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_ids(contig=None, strand=None, biotype=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20gene_ids(">gene_ids(contig=None, strand=None, biotype=None)</a></dt>
 <dd>Return all gene IDs in the annotation database, optionally restricted by
 chromosome name, strand, or <code>gene_biotype</code>.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">gene_ids_of_gene_name(gene_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20gene_ids_of_gene_name(">gene_ids_of_gene_name(gene_name)</a></dt>
 <dd>Returns all Ensembl gene IDs with the given name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">nearest_gene(contig, position, end=None, strand=None)</a></dt>
-<dd>Returns <code>(distance, <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py">Gene</a>)</code> for the gene whose locus is nearest to the
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20nearest_gene(">nearest_gene(contig, position, end=None, strand=None)</a></dt>
+<dd>Returns <code>(distance, <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py#:~:text=class%20Gene(">Gene</a>)</code> for the gene whose locus is nearest to the
 position (or position..end interval) on the given contig — even when no
 gene overlaps. Returns <code>(inf, None)</code> when no candidates exist.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">merged_gene_intervals(contig, strand=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20merged_gene_intervals(">merged_gene_intervals(contig, strand=None)</a></dt>
 <dd>Returns the union of all gene loci on the contig as a sorted list of
 non-overlapping <code>(start, end)</code> tuples. Adjacent intervals
 (<code>end+1 == next start</code>) are merged into one.</dd>
@@ -236,63 +231,59 @@ non-overlapping <code>(start, end)</code> tuples. Adjacent intervals
 ## Transcripts
 
 <dl>
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcripts(contig=None, strand=None, biotype=None)</a></dt>
-<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py">Transcript</a> objects for all transcript entries in the
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20transcripts(">transcripts(contig=None, strand=None, biotype=None)</a></dt>
+<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py#:~:text=class%20Transcript(">Transcript</a> objects for all transcript entries in the
 Ensembl database, optionally restricted to a particular contig, strand, or
 <code>transcript_biotype</code>.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_by_id(transcript_id)</a></dt>
-<dd>Construct a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py">Transcript</a> object for given Ensembl transcript ID (e.g. "ENST00000369985")</dd>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20transcript_by_id(">transcript_by_id(transcript_id)</a></dt>
+<dd>Construct a <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py#:~:text=class%20Transcript(">Transcript</a> object for given Ensembl transcript ID (e.g. "ENST00000369985")</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcripts_by_name(transcript_name)</a></dt>
-<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py">Transcript</a> objects for every transcript matching the given name.</dd>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20transcripts_by_name(">transcripts_by_name(transcript_name)</a></dt>
+<dd>Returns a list of <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py#:~:text=class%20Transcript(">Transcript</a> objects for every transcript matching the given name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_names(contig=None, strand=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20transcript_names(">transcript_names(contig=None, strand=None)</a></dt>
 <dd>Returns all transcript names in the annotation database.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_ids(contig=None, strand=None, biotype=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20transcript_ids(">transcript_ids(contig=None, strand=None, biotype=None)</a></dt>
 <dd>Returns all transcript IDs in the annotation database.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_ids_of_gene_id(gene_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20transcript_ids_of_gene_id(">transcript_ids_of_gene_id(gene_id)</a></dt>
 <dd>Return IDs of all transcripts associated with given gene ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_ids_of_gene_name(gene_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20transcript_ids_of_gene_name(">transcript_ids_of_gene_name(gene_name)</a></dt>
 <dd>Return IDs of all transcripts associated with given gene name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_ids_of_transcript_name(transcript_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20transcript_ids_of_transcript_name(">transcript_ids_of_transcript_name(transcript_name)</a></dt>
 <dd>Find all Ensembl transcript IDs with the given name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">transcript_ids_of_exon_id(exon_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20transcript_ids_of_exon_id(">transcript_ids_of_exon_id(exon_id)</a></dt>
 <dd>Return IDs of all transcripts associated with given exon ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">nearest_transcript(contig, position, end=None, strand=None)</a></dt>
-<dd>Returns <code>(distance, <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py">Transcript</a>)</code> to the closest transcript on the contig.
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20nearest_transcript(">nearest_transcript(contig, position, end=None, strand=None)</a></dt>
+<dd>Returns <code>(distance, <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py#:~:text=class%20Transcript(">Transcript</a>)</code> to the closest transcript on the contig.
 Returns <code>(inf, None)</code> when no candidates exist.</dd>
 </dl>
 
 ## Exons
 
 <dl>
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_ids(contig=None, strand=None)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20exon_ids(">exon_ids(contig=None, strand=None)</a></dt>
 <dd>Returns a list of exon IDs in the annotation database, optionally restricted
 by the given chromosome and strand.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_by_id(exon_id)</a></dt>
-<dd>Construct an <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/exon.py">Exon</a> object for given Ensembl exon ID (e.g. "ENSE00001209410")</dd>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20exon_by_id(">exon_by_id(exon_id)</a></dt>
+<dd>Construct an <a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/exon.py#:~:text=class%20Exon(">Exon</a> object for given Ensembl exon ID (e.g. "ENSE00001209410")</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_ids_of_gene_id(gene_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20exon_ids_of_gene_id(">exon_ids_of_gene_id(gene_id)</a></dt>
 <dd>Returns a list of exon IDs associated with a given gene ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_ids_of_gene_name(gene_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20exon_ids_of_gene_name(">exon_ids_of_gene_name(gene_name)</a></dt>
 <dd>Returns a list of exon IDs associated with a given gene name.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_ids_of_transcript_id(transcript_id)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20exon_ids_of_transcript_id(">exon_ids_of_transcript_id(transcript_id)</a></dt>
 <dd>Returns a list of exon IDs associated with a given transcript ID.</dd>
 
-<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py">exon_ids_of_transcript_name(transcript_name)</a></dt>
+<dt><a href="https://github.com/openvax/pyensembl/blob/main/pyensembl/genome.py#:~:text=def%20exon_ids_of_transcript_name(">exon_ids_of_transcript_name(transcript_name)</a></dt>
 <dd>Returns a list of exon IDs associated with a given transcript name.</dd>
 </dl>
-
-[gene-class]: https://github.com/openvax/pyensembl/blob/main/pyensembl/gene.py
-[transcript-class]: https://github.com/openvax/pyensembl/blob/main/pyensembl/transcript.py
-[exon-class]: https://github.com/openvax/pyensembl/blob/main/pyensembl/exon.py


### PR DESCRIPTION
## Summary

Follow-up to #353. That PR stripped `#Lnnn` anchors because they drifted on every source change, but the result linked every method to the bare `genome.py` file — which doesn't actually navigate you to the method, just opens the file.

Replaces bare-file links with **text-fragment anchors** (`#:~:text=def%20name(`). Modern browsers honor these and scroll to the first match in the rendered page. Drift-resistant: works as long as the method's `def` line exists in the file, regardless of line number.

The trailing `(` is load-bearing: `def genes` would otherwise also match `def genes_at_locus`. Same for `class Gene(` vs `class GeneFoo(` (none today, but cheap insurance).

Also removed the intro paragraph from #353 — it was an apology for the lack of precision and isn't needed now that the links land where they should.

## Test plan
- [x] 42 source links, all with method- or class-specific text-fragment anchors
- [x] `def genes(` vs `def genes_at_locus(` (and the other prefix-collision pairs) verified unique
- [x] HEAD-checked sample URLs against github.com (200 OK)
- [x] No code changes; no version bump

## Caveats

Text-fragment URLs are supported in Chrome / Edge / Firefox / Safari (Safari 16.4+). Older browsers fall back to opening the file at the top, which is no worse than #353's bare-file link.