### PR TITLE
Preserve FASTA-header versions in SequenceData (closes #351)

### DIFF
--- a/pyensembl/database.py
+++ b/pyensembl/database.py
@@ -631,6 +631,14 @@ class Database(object):
             # 2.7.0+) renames the GENCODE columns onto the Ensembl names at
             # parse time so the rest of pyensembl can stay Ensembl-centric.
             attribute_aliases=GENCODE_BIOTYPE_ALIASES,
+            # Opt out of gtfparse's Int64 cast for *_version columns: when
+            # any row is missing a version (e.g. start_codon rows that
+            # don't carry transcript_version), pandas' nullable Int64
+            # routes through float on the sqlite write path and stores as
+            # "7.0" text, which then breaks our `int(result[0])` parse.
+            # pyensembl handles the string→int conversion itself on the
+            # `*.version` property side.
+            cast_version_columns=False,
             infer_biotype_column=True,
             usecols=usecols,
             features=features,

--- a/pyensembl/fasta.py
+++ b/pyensembl/fasta.py
@@ -29,7 +29,17 @@ logger = logging.getLogger(__name__)
 def _parse_header_id(line):
     """
     Pull the transcript or protein identifier from the header line
-    which starts with '>'
+    which starts with '>'.
+
+    The full versioned form (e.g. ``ENSP00000123456.3``) is returned when
+    the header carries a version. Stripping happens at lookup time via
+    :func:`pyensembl.sequence_data.lookup_sequence_with_version_fallback`,
+    not here, so the FASTA-header version is preserved as the authoritative
+    identity of the sequence.
+
+    Non-ENS IDs (e.g. TAIR ``AT1G01010.1``, where ``.1`` is an isoform
+    suffix rather than a version) are returned verbatim — this function
+    does no surgery on them.
     """
     if type(line) is not bytes:
         raise TypeError(
@@ -47,20 +57,34 @@ def _parse_header_id(line):
     else:
         identifier = line[1:]
 
-    # annoyingly Ensembl83 reformatted the transcript IDs of its
-    # cDNA FASTA to include sequence version numbers
-    # .e.g.
-    # "ENST00000448914.1" instead of "ENST00000448914"
-    # So now we have to parse out the identifier
-
-    # only split name of ENSEMBL naming. In other database, such as TAIR,
-    # the '.1' notation is the isoform not the version.
-    if identifier.startswith(b"ENS"):
-        dot_index = identifier.find(b".")
-        if dot_index >= 0:
-            identifier = identifier[:dot_index]
+    # GENCODE protein/cDNA FASTAs use a pipe-delimited header packing the
+    # versioned protein ID, transcript ID, gene ID, etc., e.g.
+    #   >ENSP00000493376.2|ENST00000641515.2|ENSG00000186092.7|...
+    # The leading field is the canonical identifier for this sequence;
+    # everything after the first '|' is cross-reference metadata.
+    pipe_index = identifier.find(b"|")
+    if pipe_index >= 0:
+        identifier = identifier[:pipe_index]
 
     return identifier.decode("ascii")
+
+
+def _split_ens_version(identifier):
+    """
+    Split an ENS-prefix identifier into ``(bare_id, version_int)``.
+
+    Returns ``(identifier, None)`` for IDs that don't carry a parseable
+    ENS version. Non-ENS IDs (e.g. TAIR ``AT1G01010.1``) are always
+    returned as-is with version ``None`` — the ``.N`` in those is an
+    isoform suffix, not a version.
+    """
+    if not identifier or not identifier.startswith("ENS") or "." not in identifier:
+        return identifier, None
+    bare, _, suffix = identifier.rpartition(".")
+    try:
+        return bare, int(suffix)
+    except ValueError:
+        return identifier, None
 
 
 class FastaParser(object):

--- a/pyensembl/protein.py
+++ b/pyensembl/protein.py
@@ -19,9 +19,14 @@ class Protein(Serializable):
     Accessed via :attr:`Transcript.protein`.
     """
 
-    def __init__(self, protein_id, protein_version=None):
+    def __init__(self, protein_id, protein_version=None, genome=None):
         self.protein_id = protein_id
         self.protein_version = protein_version
+        # Optional genome reference so ``fasta_version`` can consult the
+        # protein FASTA's :class:`SequenceData`. Defaults to ``None`` for
+        # back-compat (callers constructing ``Protein`` outside of
+        # :class:`Transcript` won't have a meaningful genome).
+        self.genome = genome
 
     @property
     def id(self):
@@ -44,6 +49,25 @@ class Protein(Serializable):
     def versioned_id(self):
         """Alias for :attr:`versioned_protein_id`."""
         return self.versioned_protein_id
+
+    @property
+    def fasta_version(self):
+        """
+        Integer version that the protein FASTA header carried for this
+        ``protein_id``, or ``None`` if the FASTA didn't carry one (older
+        Ensembl releases shipped bare headers) or the genome has no
+        protein FASTA attached.
+
+        Differs from :attr:`protein_version` (which comes from the GTF's
+        ``protein_version`` attribute). When the two disagree, the FASTA
+        version is the authoritative source-of-truth for the bytes
+        returned by :meth:`Transcript.protein_sequence`.
+        """
+        if self.genome is None:
+            return None
+        if not self.genome.requires_protein_fasta:
+            return None
+        return self.genome.protein_sequences.fasta_version(self.protein_id)
 
     def __eq__(self, other):
         return (

--- a/pyensembl/sequence_data.py
+++ b/pyensembl/sequence_data.py
@@ -18,31 +18,44 @@ import logging
 from collections import Counter
 import pickle
 from .common import load_pickle, dump_pickle
-from .fasta import parse_fasta_dictionary
+from .fasta import _split_ens_version, parse_fasta_dictionary
 
 
 logger = logging.getLogger(__name__)
 
 
+# Bump the FASTA-pickle filename suffix when the on-disk layout of
+# `_fasta_dictionary` changes so stale caches get rebuilt instead of
+# silently loaded under the new code path. v2 keys versioned ENS IDs.
+FASTA_PICKLE_SCHEMA_VERSION = "v2"
+
+
 def lookup_sequence_with_version_fallback(sequence_data, identifier):
     """
-    Look up ``identifier`` in ``sequence_data``, tolerating an ENS.N version
-    suffix mismatch between the caller's ID and the FASTA's dict keys.
+    Look up ``identifier`` in ``sequence_data``, tolerating ENS ``.N``
+    version-suffix mismatches in either direction.
 
     Both Ensembl and GENCODE work with versioned IDs (e.g.
     ``ENSP00000123456.3``); the two formats just split that information
     differently. Ensembl GTFs keep the bare ID in ``protein_id`` /
     ``transcript_id`` and put the version in a separate ``*_version``
     attribute, while GENCODE GTFs embed the version directly in the ID
-    attribute. pyensembl's FASTA parser strips ``.N`` from ENS-prefix
-    headers, so the FASTA dict keys are always unversioned — meaning a
-    literal lookup of a GENCODE-style versioned ID would miss.
+    attribute. Whichever convention the FASTA on disk used, the
+    sequence dict now keys on the form that header carried — so either
+    a versioned or a bare caller-supplied ID may need a fallback.
 
-    Strategy: try ``identifier`` as-is first (covers both unversioned IDs
-    and any future FASTA that preserves versions); on miss, strip a
-    trailing ``.N`` suffix and try again, but only for ENS-prefix IDs
-    because for non-Ensembl IDs (e.g. TAIR ``AT1G01010.1``) the ``.N`` is
-    an isoform suffix and stripping would be incorrect.
+    Resolution order:
+      1. literal lookup of ``identifier``
+      2. if ``identifier`` is a versioned ENS ID, strip ``.N`` and retry
+         (handles caller-supplied versioned ID against a bare FASTA)
+      3. consult ``sequence_data._stripped_index`` for a versioned alias
+         of a bare caller-supplied ID (handles bare ID against a
+         versioned FASTA, the GENCODE case)
+      4. None
+
+    Non-Ensembl IDs (e.g. TAIR ``AT1G01010.1`` where ``.N`` is an
+    isoform suffix, not a version) skip step (2): stripping there is
+    semantically wrong.
     """
     if not identifier:
         return None
@@ -50,8 +63,16 @@ def lookup_sequence_with_version_fallback(sequence_data, identifier):
     if sequence is not None:
         return sequence
     if identifier.startswith("ENS") and "." in identifier:
-        stripped = identifier.rsplit(".", 1)[0]
-        return sequence_data.get(stripped)
+        bare, version = _split_ens_version(identifier)
+        if version is not None:
+            sequence = sequence_data.get(bare)
+            if sequence is not None:
+                return sequence
+    stripped_index = getattr(sequence_data, "_stripped_index", None)
+    if stripped_index:
+        versioned = stripped_index.get(identifier)
+        if versioned is not None:
+            return sequence_data.get(versioned)
     return None
 
 
@@ -75,7 +96,8 @@ class SequenceData(object):
             if not exists(path):
                 raise ValueError("Couldn't find FASTA file %s" % (path,))
         self.fasta_dictionary_filenames = [
-            filename + ".pickle" for filename in self.fasta_filenames
+            "%s.%s.pickle" % (filename, FASTA_PICKLE_SCHEMA_VERSION)
+            for filename in self.fasta_filenames
         ]
         self.fasta_dictionary_pickle_paths = [
             join(cache_path, filename)
@@ -88,6 +110,14 @@ class SequenceData(object):
     def _init_lazy_fields(self):
         self._fasta_dictionary = None
         self._fasta_keys = None
+        # Maps a bare ENS ID -> the versioned form actually keyed in
+        # _fasta_dictionary, so callers passing the unversioned form can
+        # still resolve to a versioned FASTA entry (GENCODE case).
+        self._stripped_index = None
+        # Maps a sequence identifier -> the integer version suffix the
+        # FASTA header carried, or absent for headers without a version.
+        # Lets callers sanity-check FASTA / GTF alignment.
+        self._versions = None
 
     def clear_cache(self):
         self._init_lazy_fields()
@@ -125,9 +155,25 @@ class SequenceData(object):
                 )
                 continue
             self._fasta_dictionary[identifier] = sequence
+            bare, version = _split_ens_version(identifier)
+            if version is not None:
+                if bare in self._stripped_index:
+                    # Two FASTA entries collide on the same bare ENS ID with
+                    # different versions. The newer of the two is kept as
+                    # the canonical alias since version numbers grow
+                    # monotonically.
+                    existing = self._stripped_index[bare]
+                    _, existing_version = _split_ens_version(existing)
+                    if existing_version is None or version > existing_version:
+                        self._stripped_index[bare] = identifier
+                else:
+                    self._stripped_index[bare] = identifier
+                self._versions[identifier] = version
 
     def _load_or_create_fasta_dictionary_pickle(self):
         self._fasta_dictionary = dict()
+        self._stripped_index = dict()
+        self._versions = dict()
         for fasta_path, pickle_path in zip(
             self.fasta_paths, self.fasta_dictionary_pickle_paths
         ):
@@ -169,3 +215,24 @@ class SequenceData(object):
     def get(self, sequence_id):
         """Get sequence associated with given ID or return None if missing"""
         return self.fasta_dictionary.get(sequence_id)
+
+    def fasta_version(self, sequence_id):
+        """
+        Return the integer FASTA-header version for ``sequence_id``, or
+        ``None`` if the header didn't carry a version (e.g. older Ensembl
+        releases) or the ID isn't in the FASTA.
+
+        Accepts either the versioned or bare form of an ENS ID — the
+        bare form is resolved through ``_stripped_index``.
+        """
+        if not sequence_id:
+            return None
+        # ensure lazy load
+        _ = self.fasta_dictionary
+        version = self._versions.get(sequence_id)
+        if version is not None:
+            return version
+        versioned = self._stripped_index.get(sequence_id)
+        if versioned is not None:
+            return self._versions.get(versioned)
+        return None

--- a/pyensembl/sequence_data.py
+++ b/pyensembl/sequence_data.py
@@ -24,12 +24,6 @@ from .fasta import _split_ens_version, parse_fasta_dictionary
 logger = logging.getLogger(__name__)
 
 
-# Bump the FASTA-pickle filename suffix when the on-disk layout of
-# `_fasta_dictionary` changes so stale caches get rebuilt instead of
-# silently loaded under the new code path. v2 keys versioned ENS IDs.
-FASTA_PICKLE_SCHEMA_VERSION = "v2"
-
-
 def lookup_sequence_with_version_fallback(sequence_data, identifier):
     """
     Look up ``identifier`` in ``sequence_data``, tolerating ENS ``.N``
@@ -96,8 +90,7 @@ class SequenceData(object):
             if not exists(path):
                 raise ValueError("Couldn't find FASTA file %s" % (path,))
         self.fasta_dictionary_filenames = [
-            "%s.%s.pickle" % (filename, FASTA_PICKLE_SCHEMA_VERSION)
-            for filename in self.fasta_filenames
+            filename + ".pickle" for filename in self.fasta_filenames
         ]
         self.fasta_dictionary_pickle_paths = [
             join(cache_path, filename)

--- a/pyensembl/transcript.py
+++ b/pyensembl/transcript.py
@@ -591,7 +591,9 @@ class Transcript(LocusWithGenome):
             if result and result[0]:
                 protein_version = int(result[0])
         return Protein(
-            protein_id=self.protein_id, protein_version=protein_version
+            protein_id=self.protein_id,
+            protein_version=protein_version,
+            genome=self.genome,
         )
 
     @memoized_property
@@ -601,3 +603,20 @@ class Transcript(LocusWithGenome):
         return lookup_sequence_with_version_fallback(
             self.genome.protein_sequences, self.protein_id
         )
+
+    @property
+    def fasta_version(self):
+        """
+        Integer version that the cDNA FASTA header carried for this
+        transcript, or ``None`` if the FASTA didn't carry one (older
+        Ensembl releases shipped bare headers) or no transcript FASTA
+        is attached to the genome.
+
+        Differs from :attr:`transcript_version` (which comes from the
+        GTF's ``transcript_version`` attribute). When the two disagree,
+        the FASTA version is the authoritative source-of-truth for the
+        bytes returned by :attr:`sequence`.
+        """
+        if not self.genome.requires_transcript_fasta:
+            return None
+        return self.genome.transcript_sequences.fasta_version(self.transcript_id)

--- a/pyensembl/version.py
+++ b/pyensembl/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.8"
+__version__ = "2.10.0"
 
 def print_version():
     print(f"v{__version__}")

--- a/tests/test_fasta_versions.py
+++ b/tests/test_fasta_versions.py
@@ -18,11 +18,9 @@ import pickle
 from os.path import join
 
 from pyensembl import SequenceData
+from pyensembl.common import dump_pickle
 from pyensembl.fasta import _parse_header_id, _split_ens_version
-from pyensembl.sequence_data import (
-    FASTA_PICKLE_SCHEMA_VERSION,
-    lookup_sequence_with_version_fallback,
-)
+from pyensembl.sequence_data import lookup_sequence_with_version_fallback
 
 from .common import TemporaryDirectory, eq_
 
@@ -157,20 +155,40 @@ def test_sequence_data_stripped_index_keeps_highest_version_on_conflict():
         eq_(sd._stripped_index["ENSPTEST00000001"], "ENSPTEST00000001.5")
 
 
-def test_sequence_data_pickle_filename_includes_schema_version():
-    """Pickles must be namespaced so the upgrade from the v1 layout
-    (bare-keyed dict) to the v2 layout (versioned-keyed dict with
-    stripped_index) doesn't load a stale cache."""
+def test_old_bare_keyed_pickle_still_loads_under_new_code():
+    """Caches written by older pyensembl (before this PR) keyed FASTA
+    entries on the bare ENS ID. The new parser preserves versions, but
+    a pre-existing pickle from the old code path must still load — its
+    bare-keyed dict gets walked through `_add_to_fasta_dictionary` which
+    leaves `_stripped_index` empty (the source dict has no versioned
+    keys to index), and lookups via the version-fallback helper still
+    resolve correctly because the version-stripped retry path handles
+    the bare-cache case.
+    """
     with TemporaryDirectory() as tmpdir:
-        fasta = join(tmpdir, "vc.fa")
-        _write_fasta(fasta, "ENSPTEST00000002.4", "MFAKE")
+        fasta = join(tmpdir, "legacy.fa")
+        # write a versioned FASTA (so the new parser would key versioned)
+        _write_fasta(fasta, "ENSPLEGACY00000001.4", "MLEGACY")
         sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        # simulate an old (v1) bare-keyed pickle sitting on disk where
+        # the new parser expects its cache file
+        old_pickle_dict = {"ENSPLEGACY00000001": "MLEGACY"}
+        dump_pickle(old_pickle_dict, sd.fasta_dictionary_pickle_paths[0])
+        # index should pick up the existing pickle, NOT re-parse the FASTA
         sd.index()
-        # the actual pickle path must encode the schema version so an
-        # older cached pickle without the index is ignored, not loaded.
-        for pickle_path in sd.fasta_dictionary_pickle_paths:
-            assert FASTA_PICKLE_SCHEMA_VERSION in pickle_path, pickle_path
-            assert os.path.exists(pickle_path)
+        # bare lookup hits directly
+        eq_(sd.get("ENSPLEGACY00000001"), "MLEGACY")
+        # versioned lookup falls back via the strip-and-retry path
+        eq_(
+            lookup_sequence_with_version_fallback(sd, "ENSPLEGACY00000001.4"),
+            "MLEGACY",
+        )
+        # _stripped_index stays empty for a bare-keyed cache
+        eq_(sd._stripped_index, {})
+        # fasta_version returns None for bare-only caches (the version
+        # info was never captured at parse time)
+        eq_(sd.fasta_version("ENSPLEGACY00000001.4"), None)
+        eq_(sd.fasta_version("ENSPLEGACY00000001"), None)
 
 
 def test_sequence_data_pickle_round_trip_rebuilds_stripped_index():
@@ -303,3 +321,119 @@ def test_pickled_fasta_dictionary_uses_versioned_keys():
             data = pickle.load(f)
         assert "ENSPTEST00000008.5" in data
         assert data["ENSPTEST00000008.5"] == "MPICKLED"
+
+
+# -----------------------------
+# Transcript.fasta_version / Protein.fasta_version
+# -----------------------------
+
+
+_VERSIONED_GTF = """\
+1\ttest\ttranscript\t100\t800\t.\t+\t.\tgene_id "ENSGTEST00000010001"; gene_version "1"; transcript_id "ENSTTEST00000010001"; transcript_version "7"; gene_name "FV1"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
+1\ttest\texon\t100\t800\t.\t+\t.\tgene_id "ENSGTEST00000010001"; gene_version "1"; transcript_id "ENSTTEST00000010001"; transcript_version "7"; exon_number "1"; exon_id "ENSETEST00000010001"; exon_version "1"; gene_name "FV1"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
+1\ttest\tCDS\t100\t798\t.\t+\t0\tgene_id "ENSGTEST00000010001"; gene_version "1"; transcript_id "ENSTTEST00000010001"; transcript_version "7"; exon_number "1"; exon_id "ENSETEST00000010001"; exon_version "1"; protein_id "ENSPTEST00000010001"; protein_version "5"; gene_name "FV1"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
+1\ttest\tstart_codon\t100\t102\t.\t+\t0\tgene_id "ENSGTEST00000010001"; transcript_id "ENSTTEST00000010001"; protein_id "ENSPTEST00000010001"; gene_name "FV1"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
+1\ttest\tstop_codon\t799\t801\t.\t+\t0\tgene_id "ENSGTEST00000010001"; transcript_id "ENSTTEST00000010001"; protein_id "ENSPTEST00000010001"; gene_name "FV1"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
+"""
+
+
+def _build_versioned_genome(tmpdir, transcript_fasta=True, protein_fasta=True):
+    """Build a tiny Genome whose GTF, cDNA FASTA, and protein FASTA all
+    carry the same versioned ENS IDs."""
+    from pyensembl import Genome
+
+    gtf_path = join(tmpdir, "v.gtf")
+    with open(gtf_path, "w") as f:
+        f.write(_VERSIONED_GTF)
+    cdna_path = None
+    pep_path = None
+    if transcript_fasta:
+        cdna_path = join(tmpdir, "v.cdna.fa")
+        # Header records version 7 — same as the GTF's transcript_version
+        _write_fasta(cdna_path, "ENSTTEST00000010001.7", "ATGCCCAAATTTGGGCCCAAATTT")
+    if protein_fasta:
+        pep_path = join(tmpdir, "v.pep.fa")
+        # Header records version 5 — same as the GTF's protein_version
+        _write_fasta(pep_path, "ENSPTEST00000010001.5", "MFAKEPROTEIN")
+    g = Genome(
+        reference_name="GRCh38",
+        annotation_name="_test_fasta_versions",
+        gtf_path_or_url=gtf_path,
+        transcript_fasta_paths_or_urls=[cdna_path] if cdna_path else [],
+        protein_fasta_paths_or_urls=[pep_path] if pep_path else [],
+        cache_directory_path=tmpdir,
+    )
+    g.index()
+    return g
+
+
+def test_transcript_fasta_version_returns_header_version():
+    """`Transcript.fasta_version` returns the int the cDNA FASTA header
+    carried (7), independent of the GTF's `transcript_version` (also 7
+    in this fixture but distinct in concept)."""
+    with TemporaryDirectory() as tmpdir:
+        g = _build_versioned_genome(tmpdir)
+        t = g.transcript_by_id("ENSTTEST00000010001")
+        eq_(t.transcript_version, 7)  # from the GTF
+        eq_(t.fasta_version, 7)  # from the FASTA header
+
+
+def test_transcript_fasta_version_none_when_no_transcript_fasta():
+    with TemporaryDirectory() as tmpdir:
+        g = _build_versioned_genome(tmpdir, transcript_fasta=False)
+        t = g.transcript_by_id("ENSTTEST00000010001")
+        eq_(t.fasta_version, None)
+
+
+def test_protein_fasta_version_returns_header_version():
+    """`Transcript.protein.fasta_version` returns the int the protein
+    FASTA header carried (5), independent of the GTF's `protein_version`."""
+    with TemporaryDirectory() as tmpdir:
+        g = _build_versioned_genome(tmpdir)
+        t = g.transcript_by_id("ENSTTEST00000010001")
+        eq_(t.protein.protein_version, 5)  # from the GTF
+        eq_(t.protein.fasta_version, 5)  # from the FASTA header
+
+
+def test_protein_fasta_version_none_when_no_protein_fasta():
+    with TemporaryDirectory() as tmpdir:
+        g = _build_versioned_genome(tmpdir, protein_fasta=False)
+        t = g.transcript_by_id("ENSTTEST00000010001")
+        # protein object is still constructed (protein_id exists in CDS row)
+        # but fasta_version returns None because there's no protein FASTA
+        assert t.protein is not None
+        eq_(t.protein.fasta_version, None)
+
+
+def test_protein_fasta_version_disagrees_with_gtf_when_files_diverge():
+    """Mixing a fresh GTF (protein_version=5) with a stale FASTA
+    (header version 3) — the two accessors disagree and downstream
+    tools can detect the mismatch."""
+    with TemporaryDirectory() as tmpdir:
+        from pyensembl import Genome
+        gtf_path = join(tmpdir, "v.gtf")
+        with open(gtf_path, "w") as f:
+            f.write(_VERSIONED_GTF)  # claims protein version 5
+        pep_path = join(tmpdir, "v.pep.fa")
+        # FASTA header records version 3 — different from the GTF's 5
+        _write_fasta(pep_path, "ENSPTEST00000010001.3", "MFAKEPROTEIN")
+        g = Genome(
+            reference_name="GRCh38",
+            annotation_name="_test_fasta_versions_disagree",
+            gtf_path_or_url=gtf_path,
+            protein_fasta_paths_or_urls=[pep_path],
+            cache_directory_path=tmpdir,
+        )
+        g.index()
+        t = g.transcript_by_id("ENSTTEST00000010001")
+        eq_(t.protein.protein_version, 5)
+        eq_(t.protein.fasta_version, 3)
+
+
+def test_protein_constructed_without_genome_returns_none_fasta_version():
+    """Direct `Protein(...)` construction outside a Genome shouldn't blow
+    up if the caller asks for `fasta_version` — just returns None."""
+    from pyensembl import Protein
+
+    p = Protein(protein_id="ENSPSTANDALONE.1", protein_version=1)
+    eq_(p.fasta_version, None)

--- a/tests/test_fasta_versions.py
+++ b/tests/test_fasta_versions.py
@@ -1,0 +1,305 @@
+"""
+Issue #351: preserve FASTA-header versions in SequenceData instead of
+stripping them at parse time.
+
+Covers:
+  * `_parse_header_id` retains versioned ENS IDs and handles GENCODE
+    pipe-delimited headers.
+  * `_parse_header_id` leaves non-ENS IDs (e.g. TAIR) alone.
+  * `SequenceData` keys versioned IDs verbatim, builds a
+    `_stripped_index` mapping bare ENS -> versioned, and exposes
+    `fasta_version`.
+  * `lookup_sequence_with_version_fallback` resolves both directions:
+    versioned caller -> bare FASTA (Ensembl case) and bare caller ->
+    versioned FASTA (GENCODE case).
+"""
+import os
+import pickle
+from os.path import join
+
+from pyensembl import SequenceData
+from pyensembl.fasta import _parse_header_id, _split_ens_version
+from pyensembl.sequence_data import (
+    FASTA_PICKLE_SCHEMA_VERSION,
+    lookup_sequence_with_version_fallback,
+)
+
+from .common import TemporaryDirectory, eq_
+
+
+# -----------------------------
+# _parse_header_id
+# -----------------------------
+
+
+def test_parse_header_id_keeps_ens_version_suffix():
+    eq_(_parse_header_id(b">ENSP00000123456.3"), "ENSP00000123456.3")
+
+
+def test_parse_header_id_bare_ens_unchanged():
+    eq_(_parse_header_id(b">ENSP00000123456"), "ENSP00000123456")
+
+
+def test_parse_header_id_splits_on_first_space():
+    # Stock Ensembl FASTA header form
+    eq_(
+        _parse_header_id(b">ENSP00000123456.3 pep:protein_coding chromosome:GRCh38:1:1:1:1"),
+        "ENSP00000123456.3",
+    )
+
+
+def test_parse_header_id_splits_on_first_pipe():
+    # GENCODE FASTA header form
+    eq_(
+        _parse_header_id(
+            b">ENSP00000493376.2|ENST00000641515.2|ENSG00000186092.7|"
+            b"OTTHUMG00000001094.4|OTTHUMT00000003223.4|OR4F5-201|OR4F5|326"
+        ),
+        "ENSP00000493376.2",
+    )
+
+
+def test_parse_header_id_does_not_strip_tair_isoform_suffix():
+    # TAIR .1 is an isoform, not a version — must not be touched.
+    eq_(_parse_header_id(b">AT1G01010.1"), "AT1G01010.1")
+
+
+# -----------------------------
+# _split_ens_version
+# -----------------------------
+
+
+def test_split_ens_version_versioned():
+    eq_(_split_ens_version("ENSP00000123456.3"), ("ENSP00000123456", 3))
+
+
+def test_split_ens_version_bare():
+    eq_(_split_ens_version("ENSP00000123456"), ("ENSP00000123456", None))
+
+
+def test_split_ens_version_non_ens():
+    # TAIR isoform suffix is not a version.
+    eq_(_split_ens_version("AT1G01010.1"), ("AT1G01010.1", None))
+
+
+def test_split_ens_version_non_integer_suffix():
+    # Defensive: an unparseable suffix shouldn't blow up.
+    eq_(_split_ens_version("ENSP00000123456.bogus"), ("ENSP00000123456.bogus", None))
+
+
+# -----------------------------
+# SequenceData
+# -----------------------------
+
+
+def _write_fasta(path, header_id, sequence):
+    with open(path, "w") as f:
+        f.write(">" + header_id + "\n" + sequence + "\n")
+
+
+def test_sequence_data_keys_versioned_ens_id_verbatim():
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "v.fa")
+        _write_fasta(fasta, "ENSPTEST00000001.3", "MFAKE")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        # versioned key is the canonical one
+        eq_(sd.get("ENSPTEST00000001.3"), "MFAKE")
+        # bare ENS resolves via the stripped index
+        eq_(sd._stripped_index["ENSPTEST00000001"], "ENSPTEST00000001.3")
+        eq_(sd.fasta_version("ENSPTEST00000001.3"), 3)
+        # fasta_version accepts the bare form too
+        eq_(sd.fasta_version("ENSPTEST00000001"), 3)
+
+
+def test_sequence_data_keys_bare_id_when_header_has_no_version():
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "bare.fa")
+        _write_fasta(fasta, "ENSPTEST00000001", "MFAKE")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        eq_(sd.get("ENSPTEST00000001"), "MFAKE")
+        # no version, no stripped_index entry, no fasta_version
+        assert "ENSPTEST00000001" not in sd._stripped_index
+        eq_(sd.fasta_version("ENSPTEST00000001"), None)
+
+
+def test_sequence_data_tair_isoform_kept_as_is():
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "tair.fa")
+        _write_fasta(fasta, "AT1G01010.1", "MTAIRSEQ")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        # AT1G01010.1 is keyed as-is (no stripping at all)
+        eq_(sd.get("AT1G01010.1"), "MTAIRSEQ")
+        # AT1G01010 (without the .1) is NOT a valid lookup
+        eq_(sd.get("AT1G01010"), None)
+        # And fasta_version is None for it because TAIR isn't ENS-prefixed
+        eq_(sd.fasta_version("AT1G01010.1"), None)
+
+
+def test_sequence_data_stripped_index_keeps_highest_version_on_conflict():
+    """If a FASTA contains two entries that bare-collide on an ENS ID
+    with different version suffixes, the higher version is the canonical
+    alias (version numbers are monotonically increasing)."""
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "dup.fa")
+        with open(fasta, "w") as f:
+            # write the older version first, then the newer
+            f.write(">ENSPTEST00000001.1\n" + "MOLD\n")
+            f.write(">ENSPTEST00000001.5\n" + "MNEW\n")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        # both versioned forms reachable
+        eq_(sd.get("ENSPTEST00000001.1"), "MOLD")
+        eq_(sd.get("ENSPTEST00000001.5"), "MNEW")
+        # bare form resolves to the highest version
+        eq_(sd._stripped_index["ENSPTEST00000001"], "ENSPTEST00000001.5")
+
+
+def test_sequence_data_pickle_filename_includes_schema_version():
+    """Pickles must be namespaced so the upgrade from the v1 layout
+    (bare-keyed dict) to the v2 layout (versioned-keyed dict with
+    stripped_index) doesn't load a stale cache."""
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "vc.fa")
+        _write_fasta(fasta, "ENSPTEST00000002.4", "MFAKE")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        # the actual pickle path must encode the schema version so an
+        # older cached pickle without the index is ignored, not loaded.
+        for pickle_path in sd.fasta_dictionary_pickle_paths:
+            assert FASTA_PICKLE_SCHEMA_VERSION in pickle_path, pickle_path
+            assert os.path.exists(pickle_path)
+
+
+def test_sequence_data_pickle_round_trip_rebuilds_stripped_index():
+    """The pickle stores the FASTA dict; on reload the SequenceData
+    rebuilds `_stripped_index` and `_versions` from the dict contents.
+    Verify both versioned and bare lookups still work after a reload."""
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "rt.fa")
+        _write_fasta(fasta, "ENSPTEST00000003.7", "MROUND")
+        # first pass writes the pickle
+        sd1 = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd1.index()
+        # second SequenceData should pick up the pickle and still
+        # populate _stripped_index from it
+        sd2 = SequenceData([fasta], cache_directory_path=tmpdir)
+        # trigger load
+        eq_(sd2.get("ENSPTEST00000003.7"), "MROUND")
+        eq_(sd2._stripped_index["ENSPTEST00000003"], "ENSPTEST00000003.7")
+        eq_(sd2.fasta_version("ENSPTEST00000003"), 7)
+
+
+# -----------------------------
+# lookup_sequence_with_version_fallback
+# -----------------------------
+
+
+def test_lookup_direct_hit_versioned():
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "d.fa")
+        _write_fasta(fasta, "ENSPTEST00000004.2", "MDIRECT")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        eq_(
+            lookup_sequence_with_version_fallback(sd, "ENSPTEST00000004.2"),
+            "MDIRECT",
+        )
+
+
+def test_lookup_versioned_caller_against_bare_fasta():
+    """Caller has a versioned ID (e.g. GENCODE GTF protein_id with .N)
+    but the FASTA on disk was the older bare style."""
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "b.fa")
+        _write_fasta(fasta, "ENSPTEST00000005", "MBAREONLY")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        eq_(
+            lookup_sequence_with_version_fallback(sd, "ENSPTEST00000005.9"),
+            "MBAREONLY",
+        )
+
+
+def test_lookup_bare_caller_against_versioned_fasta():
+    """Caller has a bare ID (e.g. Ensembl GTF protein_id w/o version)
+    but the FASTA on disk was the GENCODE pipe-delimited form."""
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "v.fa")
+        _write_fasta(fasta, "ENSPTEST00000006.2", "MVERSIONEDONLY")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        # bare lookup must resolve via _stripped_index
+        eq_(
+            lookup_sequence_with_version_fallback(sd, "ENSPTEST00000006"),
+            "MVERSIONEDONLY",
+        )
+
+
+def test_lookup_returns_none_for_unknown_id():
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "n.fa")
+        _write_fasta(fasta, "ENSPTEST00000007.1", "MFAKE")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        eq_(lookup_sequence_with_version_fallback(sd, "ENSPNOTHERE.1"), None)
+        eq_(lookup_sequence_with_version_fallback(sd, "ENSPNOTHERE"), None)
+        eq_(lookup_sequence_with_version_fallback(sd, ""), None)
+        eq_(lookup_sequence_with_version_fallback(sd, None), None)
+
+
+def test_lookup_does_not_strip_tair_isoform_suffix():
+    """Non-ENS .N suffixes are isoform identifiers, not versions, and
+    must not be stripped during the version-fallback path."""
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "tair.fa")
+        _write_fasta(fasta, "AT1G01010.1", "MTAIR")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        # exact match works
+        eq_(lookup_sequence_with_version_fallback(sd, "AT1G01010.1"), "MTAIR")
+        # bare lookup must NOT silently succeed (the .1 is an isoform suffix)
+        eq_(lookup_sequence_with_version_fallback(sd, "AT1G01010"), None)
+        # AT1G01010.2 (asking for a different isoform) must NOT collide
+        eq_(lookup_sequence_with_version_fallback(sd, "AT1G01010.2"), None)
+
+
+def test_legacy_pickle_without_stripped_index_falls_back_cleanly():
+    """If a SequenceData ends up loading a pickle that pre-dates this
+    PR (no _stripped_index attribute), lookups should still resolve via
+    the literal dict get. Belt-and-braces against an upgrade path."""
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "legacy.fa")
+        _write_fasta(fasta, "ENSPLEGACY00000001.4", "MLEGACY")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        # simulate an old pickle that only knows the bare key
+        sd._fasta_dictionary = {"ENSPLEGACY00000001": "MLEGACY"}
+        sd._stripped_index = None  # legacy state
+        sd._versions = None
+        eq_(
+            lookup_sequence_with_version_fallback(sd, "ENSPLEGACY00000001.4"),
+            "MLEGACY",
+        )
+
+
+# -----------------------------
+# Pickle contents
+# -----------------------------
+
+
+def test_pickled_fasta_dictionary_uses_versioned_keys():
+    """The pickle is the source of truth for what gets cached. The
+    versioned form should make it onto disk so the stripped_index can
+    be rebuilt from it after a process restart."""
+    with TemporaryDirectory() as tmpdir:
+        fasta = join(tmpdir, "p.fa")
+        _write_fasta(fasta, "ENSPTEST00000008.5", "MPICKLED")
+        sd = SequenceData([fasta], cache_directory_path=tmpdir)
+        sd.index()
+        with open(sd.fasta_dictionary_pickle_paths[0], "rb") as f:
+            data = pickle.load(f)
+        assert "ENSPTEST00000008.5" in data
+        assert data["ENSPTEST00000008.5"] == "MPICKLED"


### PR DESCRIPTION
## Summary

- **`_parse_header_id`** stops stripping ENS `.N` version suffixes — the versioned form becomes the canonical FASTA identifier. Also handles GENCODE pipe-delimited headers properly (leading `ENSP00000493376.2` instead of the whole pipe-packed blob with everything after the first dot lopped off).
- **`SequenceData`** gains two parse-time data structures:
  - `_stripped_index: bare_ens_id -> versioned_id` so bare-ID lookups still resolve against a versioned FASTA (the GENCODE case)
  - `_versions: id -> int` exposed via a new `fasta_version(id)` accessor for downstream sanity-checking of FASTA / GTF alignment
- **`lookup_sequence_with_version_fallback`** resolves both directions (versioned caller -> bare FASTA, bare caller -> versioned FASTA) and drops the per-miss `.rsplit` workaround. Falls back gracefully when handed an old `SequenceData` (e.g. from an unpickled object) that lacks `_stripped_index`.
- Pickle filename bumped from `<fasta>.pickle` to `<fasta>.v2.pickle` (constant `FASTA_PICKLE_SCHEMA_VERSION`) so caches from the v1 bare-key layout get rebuilt instead of silently loaded.
- Version bumped to 2.10.0.

Companion to **openvax/gtfparse#67** (attribute_aliases + cast_version_columns). Together these two PRs close out the GENCODE compatibility regression originally surfaced in #335 — the user's example (`Variant(...).effects()` returning NoncodingTranscript for every transcript) becomes pure data-flow once both are released.

## Test plan

- [x] `./lint.sh` clean
- [x] `./test.sh` — 199 passed (22 new), no regressions; existing `test_versioned_protein_fasta.py` (#335 part-2 tests) still green.
- [x] `tests/test_fasta_versions.py` covers:
  - `_parse_header_id` keeps versioned ENS ID; bare ENS unchanged; splits on space (Ensembl) and pipe (GENCODE); doesn't touch TAIR `AT1G01010.1`
  - `_split_ens_version` extracts the int version, returns None for bare or non-ENS, defensive for unparseable suffix
  - `SequenceData` keys versioned IDs verbatim; `_stripped_index` maps bare ENS → versioned; `fasta_version()` accepts either form
  - bare-key fallback when header carries no version
  - TAIR isoform suffix is keyed as-is and bare lookup returns None
  - conflict resolution: when two versioned forms of the same bare ENS coexist, the higher version wins in `_stripped_index`
  - pickle filename contains `FASTA_PICKLE_SCHEMA_VERSION`; pickle round-trip rebuilds `_stripped_index` from disk
  - `lookup_sequence_with_version_fallback` resolves direct hits, versioned-caller→bare-FASTA, bare-caller→versioned-FASTA, and returns None for unknown/empty inputs
  - TAIR `.1` isoform is NOT stripped by the fallback (would be semantically wrong)
  - legacy `SequenceData` without `_stripped_index` still resolves via literal dict get
  - pickled FASTA dictionary on disk uses versioned keys