### PR TITLE
CI: add Python 3.13 and 3.14 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Adds **3.13** and **3.14** to the CI test matrix (previously topped out at 3.12).

Motivation: #359 (and the earlier #318) reported the Python 3.14 argparse change where nested argument groups became a hard error. That specific bug was fixed in v2.6.2, but 3.14 was never actually exercised in CI, so we could not verify the claim. Adding it to the matrix validates 3.14 end-to-end and guards against regressions.

Notes:
- Included **3.13** as well, since it was also absent from the matrix (3.12 → nothing). If you only want 3.14, drop `"3.13"` from the list.
- This may surface remaining 3.14 issues beyond argparse (e.g. dependency wheels for numpy/polars). That is the point — CI will now tell us. If a new version is expected to be flaky, consider flipping `fail-fast: true` → `false` so one version failing does not cancel the others.

https://claude.ai/code/session_018iM7tTGPFS6ija49yAQpSM