### PR TITLE
Declare supported Python versions (3.9–3.14) in package classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,13 @@ classifiers = [
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [


### PR DESCRIPTION
Adds explicit `Programming Language :: Python :: 3.x` trove classifiers for **3.9 through 3.14**.

Previously the classifiers list had only a bare `Programming Language :: Python`, so the PyPI project page advertised no specific version support — even though `requires-python = ">=3.9"` and CI now tests 3.9–3.14 (#360, released in v2.10.2). This aligns the published metadata with what is actually tested and supported.

Metadata-only; no code or dependency changes. Can ride along with the next version bump — no dedicated release needed.

https://claude.ai/code/session_018iM7tTGPFS6ija49yAQpSM